### PR TITLE
[Blocked by PR462] feat(backend,pwa): Implement single message forwarding

### DIFF
--- a/backend/migrations/2026-06-17-025442-0000_add_message_forwarding/down.sql
+++ b/backend/migrations/2026-06-17-025442-0000_add_message_forwarding/down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS idx_messages_forwarded_from;
+
+ALTER TABLE messages
+DROP COLUMN IF EXISTS forwarded_from_message_id;

--- a/backend/migrations/2026-06-17-025442-0000_add_message_forwarding/up.sql
+++ b/backend/migrations/2026-06-17-025442-0000_add_message_forwarding/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE messages
+ADD COLUMN forwarded_from_message_id BIGINT NULL REFERENCES messages (id);

--- a/backend/src/dto/messages.rs
+++ b/backend/src/dto/messages.rs
@@ -25,6 +25,21 @@ pub struct ThreadInfo {
 
 #[derive(Debug, Serialize, Clone, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase")]
+pub struct ForwardedFromInfo {
+    pub sender: User,
+    #[serde(with = "crate::serde_i64_string")]
+    #[schema(value_type = String)]
+    pub original_chat_id: i64,
+    #[serde(with = "crate::serde_i64_string")]
+    #[schema(value_type = String)]
+    pub original_message_id: i64,
+    /// Original message's reply_to preview (non-navigable in target chat)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub original_reply_to: Option<Box<MessagePreview>>,
+}
+
+#[derive(Debug, Serialize, Clone, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct MessageResponse {
     #[serde(with = "crate::serde_i64_string")]
     #[schema(value_type = String)]
@@ -51,6 +66,8 @@ pub struct MessageResponse {
     pub reactions: Vec<ReactionSummary>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub mentions: Vec<MentionInfo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub forwarded_from: Option<ForwardedFromInfo>,
 }
 
 #[derive(Serialize, utoipa::ToSchema)]
@@ -150,6 +167,8 @@ pub struct MessagePreview {
     pub attachments: Vec<MessagePreviewAttachment>,
     pub is_deleted: bool,
     pub mentions: Vec<MentionInfo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub forwarded_from_name: Option<String>,
 }
 
 #[derive(Debug, Serialize, Clone, utoipa::ToSchema)]

--- a/backend/src/handlers/chats/messages.rs
+++ b/backend/src/handlers/chats/messages.rs
@@ -577,6 +577,7 @@ async fn post_message(
                 client_generated_id: body.client_generated_id,
                 attachment_ids,
                 publish_immediately,
+                forwarded_from_message_id: None,
             },
         )
         .await?;
@@ -699,6 +700,7 @@ pub(super) async fn post_thread_message(
                 client_generated_id: body.client_generated_id,
                 attachment_ids,
                 publish_immediately,
+                forwarded_from_message_id: None,
             },
         )
         .await?;
@@ -871,6 +873,9 @@ async fn patch_message(
 
     if message.deleted_at.is_some() {
         return Err(AppError::BadRequest("Cannot edit deleted message"));
+    }
+    if message.forwarded_from_message_id.is_some() {
+        return Err(AppError::Forbidden("Forwarded messages cannot be edited"));
     }
     if !message.is_published {
         return Err(AppError::BadRequest("Cannot edit unpublished message"));
@@ -1105,6 +1110,285 @@ async fn delete_message(
     Ok(StatusCode::NO_CONTENT)
 }
 
+/// Request body for forwarding a message.
+#[derive(serde::Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ForwardMessageBody {
+    #[serde(deserialize_with = "crate::serde_i64_string::deserialize")]
+    #[schema(value_type = String)]
+    pub source_chat_id: i64,
+    pub client_generated_id: String,
+    /// Optional: forward into a thread instead of top-level chat.
+    #[serde(
+        default,
+        deserialize_with = "crate::serde_i64_string::opt::deserialize"
+    )]
+    #[schema(value_type = Option<String>)]
+    pub thread_id: Option<i64>,
+}
+
+/// POST /chats/:target_chat_id/messages/:message_id/forward — Forward a message to a chat.
+#[utoipa::path(
+    post,
+    path = "/{message_id}/forward",
+    tag = "chats",
+    params(
+        ("chat_id" = i64, Path, description = "Target chat ID"),
+        ("message_id" = i64, Path, description = "Source message ID"),
+    ),
+    request_body = ForwardMessageBody,
+    responses(
+        (status = 201, description = "Message forwarded", body = MessageResponse),
+    ),
+    security(("uid_header" = []), ("bearer_jwt" = [])),
+)]
+async fn forward_message(
+    CurrentUid(uid): CurrentUid,
+    State(state): State<AppState>,
+    Path(MessageIdPath {
+        chat_id: target_chat_id,
+        message_id,
+    }): Path<MessageIdPath>,
+    mut conn: DbConn,
+    Json(body): Json<ForwardMessageBody>,
+) -> Result<impl IntoResponse, AppError> {
+    let conn = &mut *conn;
+
+    let source_chat_id = body.source_chat_id;
+    // Forwarder must be a member of both source and target chats.
+    check_membership(conn, source_chat_id, uid)?;
+    check_membership(conn, target_chat_id, uid)?;
+    // Load the original message from the source chat.
+    use crate::schema::messages::dsl;
+    let original: Message = messages::table
+        .filter(
+            dsl::id
+                .eq(message_id)
+                .and(dsl::chat_id.eq(source_chat_id))
+                .and(dsl::deleted_at.is_null())
+                .and(dsl::is_published.eq(true)),
+        )
+        .select(Message::as_select())
+        .first(conn)
+        .optional()?
+        .ok_or(AppError::NotFound("Message not found"))?;
+    // Reject forwarding of message types that clients are not allowed to send directly
+    // (System / Invite). Otherwise a member could forward a system or invite message into
+    // another chat, bypassing the dedicated send restrictions enforced in post_message.
+    validate_client_message_type(&original.message_type)?;
+
+    // If forwarding into a thread, validate the root message exists and is a text message.
+    let thread_root: Option<Message> = if let Some(thread_id) = body.thread_id {
+        {
+            let root: Message = messages::table
+                .filter(
+                    dsl::id
+                        .eq(thread_id)
+                        .and(dsl::chat_id.eq(target_chat_id))
+                        .and(dsl::deleted_at.is_null())
+                        .and(dsl::is_published.eq(true)),
+                )
+                .select(Message::as_select())
+                .first(conn)
+                .optional()?
+                .ok_or(AppError::NotFound("Thread root message not found"))?;
+            if root.message_type != MessageType::Text {
+                return Err(AppError::BadRequest(
+                    "Threads can only be created on text messages",
+                ));
+            }
+            Some(root)
+        }
+    } else {
+        None
+    };
+
+    // Keep message creation and side effects atomic.
+    diesel::sql_query("BEGIN").execute(conn)?;
+
+    let tx_result: Result<_, AppError> = async {
+        // Re-validate inside the transaction: the original was loaded before BEGIN, so a
+        // concurrent soft-delete could race. Re-check non-deleted + published here.
+        let original_still_valid: bool = messages::table
+            .filter(
+                dsl::id
+                    .eq(message_id)
+                    .and(dsl::chat_id.eq(source_chat_id))
+                    .and(dsl::deleted_at.is_null())
+                    .and(dsl::is_published.eq(true)),
+            )
+            .count()
+            .get_result::<i64>(conn)?
+            > 0;
+        if !original_still_valid {
+            return Err(AppError::NotFound("Message not found"));
+        }
+        // forwarded_from_message_id always stores the root message ID,
+        // so no chain resolution is needed.
+        let root_message_id = original.forwarded_from_message_id.unwrap_or(original.id);
+
+        // Clone attachments from the original message BEFORE send_prepared_message
+        // so the WebSocket broadcast includes them.
+        use crate::schema::attachments::dsl as a_dsl;
+        let original_attachments: Vec<crate::models::Attachment> = attachments::table
+            .filter(a_dsl::message_id.eq(original.id))
+            .select(crate::models::Attachment::as_select())
+            .load(conn)?;
+
+        let mut cloned_attachment_ids: Vec<i64> = Vec::new();
+        for att in &original_attachments {
+            let new_id = crate::utils::ids::next_message_id(state.id_gen.as_ref())
+                .await
+                .map_err(|e| {
+                    tracing::error!("next_message_id for forwarded attachment: {:?}", e);
+                    AppError::Internal("Failed to generate attachment ID")
+                })?;
+            // Insert with message_id = None; send_prepared_message will link them.
+            diesel::insert_into(attachments::table)
+                .values(&crate::models::NewAttachment {
+                    id: new_id,
+                    message_id: None,
+                    file_name: att.file_name.clone(),
+                    kind: att.kind.clone(),
+                    external_reference: att.external_reference.clone(),
+                    size: att.size,
+                    created_at: att.created_at,
+                    deleted_at: att.deleted_at,
+                    width: att.width,
+                    height: att.height,
+                    order: att.order,
+                })
+                .execute(conn)?;
+            cloned_attachment_ids.push(new_id);
+        }
+
+        let send_result = super::send_prepared_message(
+            conn,
+            &state,
+            super::PreparedMessageSend {
+                chat_id: target_chat_id,
+                sender_uid: uid,
+                message: original.message.clone(),
+                message_type: original.message_type.clone(),
+                sticker_id: original.sticker_id,
+                reply_to_id: None,
+                reply_root_id: body.thread_id,
+                client_generated_id: body.client_generated_id,
+                attachment_ids: cloned_attachment_ids,
+                publish_immediately: true,
+                forwarded_from_message_id: Some(root_message_id),
+            },
+        )
+        .await?;
+
+        let super::SendMessageOutcome::Created(created) = &send_result else {
+            return Ok(send_result);
+        };
+        let inserted_msg = &created.inserted_message;
+
+        // If forwarding into a thread, fire thread-specific side effects.
+        if let (Some(thread_id), Some(root)) = (body.thread_id, &thread_root) {
+            crate::services::threads::ensure_thread_subscription(
+                conn,
+                target_chat_id,
+                thread_id,
+                uid,
+            )?;
+            crate::services::threads::mark_thread_as_read(
+                conn,
+                target_chat_id,
+                thread_id,
+                uid,
+                inserted_msg.id,
+            )?;
+            // Auto-subscribe the root message author if different from forwarder.
+            if root.sender_uid != uid {
+                crate::services::threads::ensure_thread_user_state(
+                    conn,
+                    target_chat_id,
+                    thread_id,
+                    root.sender_uid,
+                    true,
+                )?;
+            }
+            crate::services::threads::increment_thread_meta(
+                conn,
+                target_chat_id,
+                thread_id,
+                inserted_msg.created_at,
+            )?;
+            // Mark the root message as having a thread.
+            diesel::update(messages::table.filter(dsl::id.eq(thread_id)))
+                .set(dsl::has_thread.eq(true))
+                .execute(conn)?;
+            // Auto-subscribe mentioned users (mirrors post_thread_message) so they receive
+            // subsequent ThreadUpdate broadcasts, not just this forward's push notification.
+            if let Some(ref text) = original.message {
+                for mentioned_uid in extract_mention_uids(text) {
+                    if mentioned_uid != uid {
+                        crate::services::threads::ensure_thread_subscription(
+                            conn,
+                            target_chat_id,
+                            thread_id,
+                            mentioned_uid,
+                        )?;
+                    }
+                }
+            }
+        }
+        Ok(send_result)
+    }
+    .await;
+
+    match tx_result {
+        Ok(send_result) => {
+            diesel::sql_query("COMMIT").execute(conn)?;
+
+            let response = match send_result {
+                super::SendMessageOutcome::Created(created) => {
+                    // If forwarding into a thread, broadcast thread update to subscribers.
+                    if let Some(thread_id) = body.thread_id {
+                        if let Err(err) =
+                            crate::services::threads::broadcast_thread_update_to_subscribers(
+                                conn,
+                                &state.ws_registry,
+                                target_chat_id,
+                                thread_id,
+                            )
+                        {
+                            tracing::warn!(
+                                target_chat_id,
+                                thread_id,
+                                ?err,
+                                "failed to broadcast thread update after forward"
+                            );
+                        }
+                    }
+                    if let Some(search_service) = state.message_search.clone() {
+                        search_service.upsert_message_best_effort(created.inserted_message.clone());
+                    }
+                    created.side_effects.fire(&state);
+
+                    super::attach_metadata(conn, vec![created.inserted_message], &state, uid)
+                        .await
+                        .into_iter()
+                        .next()
+                        .unwrap()
+                }
+                // Client retry with the same client_generated_id: return the previously created
+                // forwarded message instead of panicking. The original forward already
+                // succeeded and was committed, so this is a safe idempotent replay.
+                super::SendMessageOutcome::Duplicate(response) => *response,
+            };
+
+            Ok((StatusCode::CREATED, Json(response)).into_response())
+        }
+        Err(e) => {
+            diesel::sql_query("ROLLBACK").execute(conn)?;
+            Err(e)
+        }
+    }
+}
 pub fn router() -> OpenApiRouter<crate::AppState> {
     OpenApiRouter::new()
         .routes(utoipa_axum::routes!(get_messages, post_message))
@@ -1112,7 +1396,8 @@ pub fn router() -> OpenApiRouter<crate::AppState> {
         .routes(utoipa_axum::routes!(
             get_message,
             patch_message,
-            delete_message
+            delete_message,
+            forward_message
         ))
 }
 

--- a/backend/src/handlers/chats/messages.rs
+++ b/backend/src/handlers/chats/messages.rs
@@ -517,7 +517,10 @@ async fn get_message(
         .ok_or(AppError::NotFound("Message not found"))?;
 
     let messages_vec = attach_metadata(conn, vec![message], &state, uid).await;
-    let response = messages_vec.into_iter().next().unwrap();
+    let response = messages_vec
+        .into_iter()
+        .next()
+        .ok_or(AppError::Internal("Failed to build message response"))?;
 
     Ok(Json(response))
 }
@@ -619,6 +622,112 @@ async fn post_message(
     Ok((StatusCode::CREATED, Json(response)))
 }
 
+/// Load and validate a thread root message.
+/// Returns NotFound if the message doesn't exist, BadRequest if it's not a text message.
+fn load_thread_root_message(
+    conn: &mut diesel::PgConnection,
+    thread_id: i64,
+    chat_id: i64,
+) -> Result<Message, AppError> {
+    let root: Message = messages::table
+        .filter(
+            dsl::id
+                .eq(thread_id)
+                .and(dsl::chat_id.eq(chat_id))
+                // Removed: .and(dsl::deleted_at.is_null()) — deleted roots must stay reachable.
+                .and(dsl::is_published.eq(true)),
+        )
+        .select(Message::as_select())
+        .first(conn)
+        .optional()?
+        .ok_or(AppError::NotFound("Thread root message not found"))?;
+    // Block creating new threads on deleted messages that have no existing thread.
+    // A deleted message with has_thread=false means the discussion is fully terminated.
+    if root.deleted_at.is_some() && !root.has_thread {
+        return Err(AppError::BadRequest(
+            "Cannot create a thread on a deleted message with no existing replies",
+        ));
+    }
+
+    // Skip message-type check for deleted roots - the thread already exists.
+    // Invariant: only Text messages can ever acquire has_thread=true (enforced in
+    // post_thread_message above), so a deleted root is guaranteed to be Text and
+    // does not need re-validation. We skip solely because message_type is not
+    // reliable for deleted rows that may have been redacted.
+    if root.deleted_at.is_none() && root.message_type != MessageType::Text {
+        return Err(AppError::BadRequest(
+            "Threads can only be created on text messages",
+        ));
+    }
+    Ok(root)
+}
+
+/// Best-effort thread-update broadcast: log a warning on failure instead of
+/// propagating the error. Thread-update delivery must never roll back an
+/// otherwise-successful message create/delete/forward.
+fn broadcast_thread_update_safely(
+    conn: &mut diesel::PgConnection,
+    state: &AppState,
+    chat_id: i64,
+    thread_id: i64,
+) {
+    if let Err(err) = crate::services::threads::broadcast_thread_update_to_subscribers(
+        conn,
+        &state.ws_registry,
+        chat_id,
+        thread_id,
+    ) {
+        tracing::warn!(
+            chat_id,
+            thread_id,
+            ?err,
+            "failed to broadcast thread update to subscribers"
+        );
+    }
+}
+
+/// Clone all attachments belonging to `source_message_id` into new attachment rows
+/// (message_id = None; send_prepared_message links them later). Returns generated
+/// attachment IDs in original order. Used by message forwarding.
+async fn clone_attachments_for_forward(
+    conn: &mut diesel::PgConnection,
+    source_message_id: i64,
+    id_gen: &crate::utils::ids::IdGen,
+) -> Result<Vec<i64>, AppError> {
+    use crate::schema::attachments::dsl as a_dsl;
+    let original_attachments: Vec<crate::models::Attachment> = attachments::table
+        .filter(a_dsl::message_id.eq(source_message_id))
+        .select(crate::models::Attachment::as_select())
+        .load(conn)?;
+
+    let mut cloned_attachment_ids: Vec<i64> = Vec::new();
+    for att in &original_attachments {
+        let new_id = crate::utils::ids::next_message_id(id_gen)
+            .await
+            .map_err(|e| {
+                tracing::error!("next_message_id for forwarded attachment: {:?}", e);
+                AppError::Internal("Failed to generate attachment ID")
+            })?;
+        // Insert with message_id = None; send_prepared_message will link them.
+        diesel::insert_into(attachments::table)
+            .values(&crate::models::NewAttachment {
+                id: new_id,
+                message_id: None,
+                file_name: att.file_name.clone(),
+                kind: att.kind.clone(),
+                external_reference: att.external_reference.clone(),
+                size: att.size,
+                created_at: att.created_at,
+                deleted_at: att.deleted_at,
+                width: att.width,
+                height: att.height,
+                order: att.order,
+            })
+            .execute(conn)?;
+        cloned_attachment_ids.push(new_id);
+    }
+    Ok(cloned_attachment_ids)
+}
 /// POST /chats/:chat_id/threads/:thread_id/messages — Send a message in a thread.
 #[utoipa::path(
     post,
@@ -646,29 +755,9 @@ pub(super) async fn post_thread_message(
     check_membership(conn, chat_id, uid)?;
     validate_client_message_type(&body.message_type)?;
 
-    // Load root message: validate existence. Allow deleted roots only when a
-    // thread already exists (has_thread=true) so existing discussions stay usable.
-    // A deleted message with has_thread=false means the discussion is fully
-    // terminated, so it's excluded here and surfaces as NotFound.
-
-    let root_msg: Message = messages::table
-        .filter(
-            dsl::id
-                .eq(thread_id)
-                .and(dsl::chat_id.eq(chat_id))
-                .and(dsl::is_published.eq(true))
-                .and(dsl::deleted_at.is_null().or(dsl::has_thread.eq(true))),
-        )
-        .select(Message::as_select())
-        .first(conn)
-        .optional()?
-        .ok_or(AppError::NotFound("Thread root message not found"))?;
-
-    if root_msg.message_type != MessageType::Text {
-        return Err(AppError::BadRequest(
-            "Threads can only be created on text messages",
-        ));
-    }
+    // Load root message: validate existence and message type. Allow deleted roots so
+    // threads remain usable (see load_thread_root_message for the deleted-root invariant).
+    let root_msg = load_thread_root_message(conn, thread_id, chat_id)?;
     let attachment_ids: Vec<i64> = body
         .attachment_ids
         .iter()
@@ -811,19 +900,7 @@ pub(super) async fn post_thread_message(
             state.ws_registry.broadcast_to_uids(&member_uids, ws_msg);
         }
 
-        if let Err(err) = crate::services::threads::broadcast_thread_update_to_subscribers(
-            conn,
-            &state.ws_registry,
-            chat_id,
-            thread_id,
-        ) {
-            tracing::warn!(
-                chat_id,
-                thread_id,
-                ?err,
-                "failed to broadcast thread update to subscribers"
-            );
-        }
+        broadcast_thread_update_safely(conn, &state, chat_id, thread_id);
     }
 
     Ok((StatusCode::CREATED, Json(response)))
@@ -1068,19 +1145,7 @@ async fn delete_message(
     // last_reply_at) to subscribers for the thread-list view. The parent-chat bubble
     // badge is refreshed for ALL members by the MessageUpdated(root) broadcast below.
     if let Some(reply_root_id) = response.reply_root_id {
-        if let Err(err) = crate::services::threads::broadcast_thread_update_to_subscribers(
-            conn,
-            &state.ws_registry,
-            chat_id,
-            reply_root_id,
-        ) {
-            tracing::warn!(
-                chat_id,
-                reply_root_id,
-                ?err,
-                "failed to broadcast thread update after reply deletion"
-            );
-        }
+        broadcast_thread_update_safely(conn, &state, chat_id, reply_root_id);
     }
 
     // Broadcast the updated root message to ALL members so the thread-reply
@@ -1179,26 +1244,7 @@ async fn forward_message(
 
     // If forwarding into a thread, validate the root message exists and is a text message.
     let thread_root: Option<Message> = if let Some(thread_id) = body.thread_id {
-        {
-            let root: Message = messages::table
-                .filter(
-                    dsl::id
-                        .eq(thread_id)
-                        .and(dsl::chat_id.eq(target_chat_id))
-                        .and(dsl::deleted_at.is_null())
-                        .and(dsl::is_published.eq(true)),
-                )
-                .select(Message::as_select())
-                .first(conn)
-                .optional()?
-                .ok_or(AppError::NotFound("Thread root message not found"))?;
-            if root.message_type != MessageType::Text {
-                return Err(AppError::BadRequest(
-                    "Threads can only be created on text messages",
-                ));
-            }
-            Some(root)
-        }
+        Some(load_thread_root_message(conn, thread_id, target_chat_id)?)
     } else {
         None
     };
@@ -1229,38 +1275,8 @@ async fn forward_message(
 
         // Clone attachments from the original message BEFORE send_prepared_message
         // so the WebSocket broadcast includes them.
-        use crate::schema::attachments::dsl as a_dsl;
-        let original_attachments: Vec<crate::models::Attachment> = attachments::table
-            .filter(a_dsl::message_id.eq(original.id))
-            .select(crate::models::Attachment::as_select())
-            .load(conn)?;
-
-        let mut cloned_attachment_ids: Vec<i64> = Vec::new();
-        for att in &original_attachments {
-            let new_id = crate::utils::ids::next_message_id(state.id_gen.as_ref())
-                .await
-                .map_err(|e| {
-                    tracing::error!("next_message_id for forwarded attachment: {:?}", e);
-                    AppError::Internal("Failed to generate attachment ID")
-                })?;
-            // Insert with message_id = None; send_prepared_message will link them.
-            diesel::insert_into(attachments::table)
-                .values(&crate::models::NewAttachment {
-                    id: new_id,
-                    message_id: None,
-                    file_name: att.file_name.clone(),
-                    kind: att.kind.clone(),
-                    external_reference: att.external_reference.clone(),
-                    size: att.size,
-                    created_at: att.created_at,
-                    deleted_at: att.deleted_at,
-                    width: att.width,
-                    height: att.height,
-                    order: att.order,
-                })
-                .execute(conn)?;
-            cloned_attachment_ids.push(new_id);
-        }
+        let cloned_attachment_ids =
+            clone_attachments_for_forward(conn, original.id, state.id_gen.as_ref()).await?;
 
         let send_result = super::send_prepared_message(
             conn,
@@ -1348,21 +1364,7 @@ async fn forward_message(
                 super::SendMessageOutcome::Created(created) => {
                     // If forwarding into a thread, broadcast thread update to subscribers.
                     if let Some(thread_id) = body.thread_id {
-                        if let Err(err) =
-                            crate::services::threads::broadcast_thread_update_to_subscribers(
-                                conn,
-                                &state.ws_registry,
-                                target_chat_id,
-                                thread_id,
-                            )
-                        {
-                            tracing::warn!(
-                                target_chat_id,
-                                thread_id,
-                                ?err,
-                                "failed to broadcast thread update after forward"
-                            );
-                        }
+                        broadcast_thread_update_safely(conn, &state, target_chat_id, thread_id);
                     }
                     if let Some(search_service) = state.message_search.clone() {
                         search_service.upsert_message_best_effort(created.inserted_message.clone());
@@ -1384,7 +1386,7 @@ async fn forward_message(
             Ok((StatusCode::CREATED, Json(response)).into_response())
         }
         Err(e) => {
-            diesel::sql_query("ROLLBACK").execute(conn)?;
+            let _ = diesel::sql_query("ROLLBACK").execute(conn);
             Err(e)
         }
     }

--- a/backend/src/handlers/chats/mod.rs
+++ b/backend/src/handlers/chats/mod.rs
@@ -17,9 +17,9 @@ use crate::{
         attachments::AttachmentResponse,
         chats::{ChatListItem, ListChatsResponse, MarkChatReadStateResponse, UnreadCountResponse},
         messages::{
-            MentionInfo, MessagePreview, MessagePreviewAttachment, MessagePreviewSticker,
-            MessageResponse, MessageStickerResponse, ReactionReactor, ReactionSummary,
-            StickerMediaResponse, ThreadInfo,
+            ForwardedFromInfo, MentionInfo, MessagePreview, MessagePreviewAttachment,
+            MessagePreviewSticker, MessageResponse, MessageStickerResponse, ReactionReactor,
+            ReactionSummary, StickerMediaResponse, ThreadInfo,
         },
         users::User,
         ws::{ChatArchiveStateChangedPayload, ServerWsMessage},
@@ -111,6 +111,7 @@ pub(crate) struct PreparedMessageSend {
     pub client_generated_id: String,
     pub attachment_ids: Vec<i64>,
     pub publish_immediately: bool,
+    pub forwarded_from_message_id: Option<i64>,
 }
 
 pub(crate) struct SendMessageResult {
@@ -347,6 +348,7 @@ fn message_response_preview(response: MessageResponse) -> MessagePreview {
             .collect(),
         is_deleted,
         mentions: response.mentions,
+        forwarded_from_name: response.forwarded_from.and_then(|fwd| fwd.sender.name),
     }
 }
 
@@ -392,6 +394,7 @@ pub(crate) struct MessagePreviewInput {
     pub deleted_at: Option<DateTime<Utc>>,
     pub mention_source: Option<String>,
     pub mention_uids: Option<Vec<i32>>,
+    pub forwarded_from_message_id: Option<i64>,
 }
 
 pub(crate) fn build_message_preview(
@@ -399,6 +402,7 @@ pub(crate) fn build_message_preview(
     sticker_emoji_map: &std::collections::HashMap<i64, String>,
     user_avatars: &std::collections::HashMap<i32, Option<String>>,
     user_profiles: &std::collections::HashMap<i32, UserProfile>,
+    fwd_messages_map: &std::collections::HashMap<i64, crate::models::Message>,
 ) -> MessagePreview {
     let MessagePreviewInput {
         id,
@@ -412,6 +416,7 @@ pub(crate) fn build_message_preview(
         deleted_at,
         mention_source,
         mention_uids,
+        forwarded_from_message_id,
     } = input;
     let is_deleted = deleted_at.is_some();
     let sticker_emoji = sticker_id.and_then(|sid| sticker_emoji_map.get(&sid).cloned());
@@ -443,6 +448,17 @@ pub(crate) fn build_message_preview(
                 })
             })
             .unwrap_or_default(),
+        forwarded_from_name: if is_deleted {
+            None
+        } else {
+            forwarded_from_message_id.and_then(|fwd_id| {
+                fwd_messages_map.get(&fwd_id).map(|fwd_msg| {
+                    build_sender(fwd_msg.sender_uid, user_avatars, user_profiles)
+                        .name
+                        .unwrap_or_else(|| "Unknown".to_string())
+                })
+            })
+        },
     }
 }
 
@@ -701,6 +717,7 @@ pub(crate) async fn send_prepared_message(
         has_reactions: false,
         is_published: prepared.publish_immediately,
         transcode_status,
+        forwarded_from_message_id: prepared.forwarded_from_message_id,
     };
 
     let inserted_msg: Option<Message> = diesel::insert_into(messages_schema::table)
@@ -822,6 +839,7 @@ fn validate_idempotent_message_payload(
         && existing.reply_to_id == prepared.reply_to_id
         && existing.reply_root_id == prepared.reply_root_id
         && attachment_ids_match
+        && existing.forwarded_from_message_id == prepared.forwarded_from_message_id
     {
         return Ok(());
     }
@@ -872,12 +890,42 @@ pub async fn attach_metadata(
         })
     });
 
+    // Load forwarded-from messages' reply_to for preview building.
+    let fwd_message_ids: Vec<i64> = messages_to_process
+        .iter()
+        .filter_map(|m| m.forwarded_from_message_id)
+        .collect();
+    let fwd_messages_map: std::collections::HashMap<i64, crate::models::Message> =
+        if !fwd_message_ids.is_empty() {
+            use crate::schema::messages::dsl as m_dsl;
+            messages_schema::table
+                .filter(m_dsl::id.eq_any(&fwd_message_ids))
+                .select(crate::models::Message::as_select())
+                .load(conn)
+                .unwrap_or_default()
+                .into_iter()
+                .map(|m: crate::models::Message| (m.id, m))
+                .collect()
+        } else {
+            std::collections::HashMap::new()
+        };
+
+    let fwd_reply_ids: Vec<i64> = fwd_messages_map
+        .values()
+        .filter_map(|m| m.reply_to_id)
+        .collect();
+    let fwd_reply_messages_map = load_reply_messages(conn, &fwd_reply_ids).unwrap_or_default();
+
     let mut avatar_uids = std::collections::HashSet::new();
     for m in &messages_to_process {
         avatar_uids.insert(m.sender_uid);
     }
     for reply_msg in reply_messages_map.values() {
         avatar_uids.insert(reply_msg.sender_uid);
+    }
+    // Also collect forwarded-from sender UIDs for avatar resolution.
+    for fwd_msg in fwd_messages_map.values() {
+        avatar_uids.insert(fwd_msg.sender_uid);
     }
     let target_uids: Vec<i32> = avatar_uids.into_iter().collect();
     let mut user_avatars = lookup_user_avatars(state, &target_uids);
@@ -1131,10 +1179,12 @@ pub async fn attach_metadata(
                         deleted_at: reply_msg.deleted_at,
                         mention_source: reply_msg.message.clone(),
                         mention_uids: None,
+                        forwarded_from_message_id: reply_msg.forwarded_from_message_id,
                     },
                     &sticker_emoji_map,
                     &user_avatars,
                     &user_profiles,
+                    &fwd_messages_map,
                 );
                 Box::new(preview)
             });
@@ -1157,10 +1207,11 @@ pub async fn attach_metadata(
         }
 
         let is_deleted = m.deleted_at.is_some();
+        let msg_type = m.message_type;
         let mut response = MessageResponse {
             id: m.id,
             message: if is_deleted { None } else { m.message },
-            message_type: m.message_type,
+            message_type: msg_type.clone(),
             sticker: m.sticker_id.and_then(|sticker_id| {
                 (!is_deleted)
                     .then(|| {
@@ -1198,6 +1249,51 @@ pub async fn attach_metadata(
                     .iter()
                     .map(|&uid| build_mention_info(uid, &user_avatars, &user_profiles))
                     .collect()
+            },
+            // Stickers forwarded look identical to self-sent: no forwarded-from info.
+            forwarded_from: if msg_type == MessageType::Sticker {
+                None
+            } else {
+                m.forwarded_from_message_id.and_then(|fwd_msg_id| {
+                    let original = fwd_messages_map.get(&fwd_msg_id)?;
+                    let original_reply_to = original.reply_to_id.and_then(|reply_id| {
+                        fwd_reply_messages_map.get(&reply_id).map(|reply_msg| {
+                            Box::new(MessagePreview {
+                                id: reply_msg.id,
+                                client_generated_id: reply_msg.client_generated_id.clone(),
+                                created_at: reply_msg.created_at,
+                                sender: build_sender(
+                                    reply_msg.sender_uid,
+                                    &user_avatars,
+                                    &user_profiles,
+                                ),
+                                message: if reply_msg.deleted_at.is_some() {
+                                    None
+                                } else {
+                                    reply_msg.message.clone()
+                                },
+                                message_type: reply_msg.message_type.clone(),
+                                sticker: reply_msg.sticker_id.and_then(|sid| {
+                                    sticker_rows.get(&sid).map(|(sticker, _)| {
+                                        MessagePreviewSticker {
+                                            emoji: sticker.emoji.clone(),
+                                        }
+                                    })
+                                }),
+                                is_deleted: reply_msg.deleted_at.is_some(),
+                                attachments: Vec::new(),
+                                mentions: Vec::new(),
+                                forwarded_from_name: None,
+                            })
+                        })
+                    });
+                    Some(ForwardedFromInfo {
+                        sender: build_sender(original.sender_uid, &user_avatars, &user_profiles),
+                        original_chat_id: original.chat_id,
+                        original_message_id: fwd_msg_id,
+                        original_reply_to,
+                    })
+                })
             },
         };
         redact_deleted_message_response(&mut response);
@@ -1921,6 +2017,7 @@ mod tests {
             sticker_id: None,
             is_published: true,
             transcode_status: TranscodeStatus::None,
+            forwarded_from_message_id: None,
         };
         patch(&mut message);
         message
@@ -2114,6 +2211,7 @@ mod tests {
             sticker_id: None,
             is_published: true,
             transcode_status: TranscodeStatus::None,
+            forwarded_from_message_id: None,
         }
     }
 
@@ -2129,6 +2227,7 @@ mod tests {
             client_generated_id: "client-1".to_string(),
             attachment_ids: vec![10, 11],
             publish_immediately: true,
+            forwarded_from_message_id: None,
         }
     }
 
@@ -2158,6 +2257,7 @@ mod tests {
             attachments: Vec::new(),
             reactions: Vec::new(),
             mentions: Vec::new(),
+            forwarded_from: None,
         };
 
         let preview = build_push_preview_bundle(&response);
@@ -2200,6 +2300,7 @@ mod tests {
             }],
             reactions: Vec::new(),
             mentions: Vec::new(),
+            forwarded_from: None,
         };
 
         let preview = build_push_preview_bundle(&response);
@@ -2237,6 +2338,7 @@ mod tests {
             }],
             is_deleted: false,
             mentions: Vec::new(),
+            forwarded_from_name: None,
         };
 
         let value = serde_json::to_value(reply).expect("serialize reply_to_message");
@@ -2305,6 +2407,7 @@ mod tests {
                 gender: 0,
                 user_group: None,
             }],
+            forwarded_from: None,
         };
 
         redact_deleted_message_response(&mut response);
@@ -2344,8 +2447,10 @@ mod tests {
                 deleted_at: Some(Utc::now()),
                 mention_source: Some("@mention".to_string()),
                 mention_uids: None,
+                forwarded_from_message_id: None,
             },
             &sticker_map,
+            &HashMap::new(),
             &HashMap::new(),
             &HashMap::new(),
         );

--- a/backend/src/handlers/chats/mod.rs
+++ b/backend/src/handlers/chats/mod.rs
@@ -902,6 +902,9 @@ pub async fn attach_metadata(
                 .filter(m_dsl::id.eq_any(&fwd_message_ids))
                 .select(crate::models::Message::as_select())
                 .load(conn)
+                .map_err(|e| {
+                    tracing::warn!(error = ?e, "failed to load forwarded-from messages");
+                })
                 .unwrap_or_default()
                 .into_iter()
                 .map(|m: crate::models::Message| (m.id, m))
@@ -1258,33 +1261,35 @@ pub async fn attach_metadata(
                     let original = fwd_messages_map.get(&fwd_msg_id)?;
                     let original_reply_to = original.reply_to_id.and_then(|reply_id| {
                         fwd_reply_messages_map.get(&reply_id).map(|reply_msg| {
-                            Box::new(MessagePreview {
-                                id: reply_msg.id,
-                                client_generated_id: reply_msg.client_generated_id.clone(),
-                                created_at: reply_msg.created_at,
-                                sender: build_sender(
-                                    reply_msg.sender_uid,
-                                    &user_avatars,
-                                    &user_profiles,
-                                ),
-                                message: if reply_msg.deleted_at.is_some() {
-                                    None
-                                } else {
-                                    reply_msg.message.clone()
+                            let reply_sticker_emoji_map: std::collections::HashMap<i64, String> =
+                                sticker_rows
+                                    .iter()
+                                    .map(|(id, (sticker, _))| (*id, sticker.emoji.clone()))
+                                    .collect();
+                            Box::new(build_message_preview(
+                                MessagePreviewInput {
+                                    id: reply_msg.id,
+                                    client_generated_id: reply_msg.client_generated_id.clone(),
+                                    created_at: reply_msg.created_at,
+                                    sender: build_sender(
+                                        reply_msg.sender_uid,
+                                        &user_avatars,
+                                        &user_profiles,
+                                    ),
+                                    message: reply_msg.message.clone(),
+                                    message_type: reply_msg.message_type.clone(),
+                                    sticker_id: reply_msg.sticker_id,
+                                    attachments: Vec::new(),
+                                    deleted_at: reply_msg.deleted_at,
+                                    mention_source: None,
+                                    mention_uids: None,
+                                    forwarded_from_message_id: None,
                                 },
-                                message_type: reply_msg.message_type.clone(),
-                                sticker: reply_msg.sticker_id.and_then(|sid| {
-                                    sticker_rows.get(&sid).map(|(sticker, _)| {
-                                        MessagePreviewSticker {
-                                            emoji: sticker.emoji.clone(),
-                                        }
-                                    })
-                                }),
-                                is_deleted: reply_msg.deleted_at.is_some(),
-                                attachments: Vec::new(),
-                                mentions: Vec::new(),
-                                forwarded_from_name: None,
-                            })
+                                &reply_sticker_emoji_map,
+                                &user_avatars,
+                                &user_profiles,
+                                &fwd_messages_map,
+                            ))
                         })
                     });
                     Some(ForwardedFromInfo {

--- a/backend/src/handlers/chats/mod.rs
+++ b/backend/src/handlers/chats/mod.rs
@@ -895,7 +895,7 @@ pub async fn attach_metadata(
         .iter()
         .filter_map(|m| m.forwarded_from_message_id)
         .collect();
-    let fwd_messages_map: std::collections::HashMap<i64, crate::models::Message> =
+    let mut fwd_messages_map: std::collections::HashMap<i64, crate::models::Message> =
         if !fwd_message_ids.is_empty() {
             use crate::schema::messages::dsl as m_dsl;
             messages_schema::table
@@ -918,6 +918,29 @@ pub async fn attach_metadata(
         .filter_map(|m| m.reply_to_id)
         .collect();
     let fwd_reply_messages_map = load_reply_messages(conn, &fwd_reply_ids).unwrap_or_default();
+
+    // Inner replies inside forwarded messages may themselves be forwarded.
+    // Load those forwarded-origin messages so the nested reply preview can
+    // resolve its own `forwarded_from_name`.
+    let fwd_reply_fwd_ids: Vec<i64> = fwd_reply_messages_map
+        .values()
+        .filter_map(|m| m.forwarded_from_message_id)
+        .filter(|id| !fwd_messages_map.contains_key(id))
+        .collect();
+    if !fwd_reply_fwd_ids.is_empty() {
+        use crate::schema::messages::dsl as m_dsl;
+        let extra: Vec<crate::models::Message> = messages_schema::table
+            .filter(m_dsl::id.eq_any(&fwd_reply_fwd_ids))
+            .select(crate::models::Message::as_select())
+            .load(conn)
+            .map_err(|e| {
+                tracing::warn!(error = ?e, "failed to load nested forwarded-from messages");
+            })
+            .unwrap_or_default();
+        for m in extra {
+            fwd_messages_map.entry(m.id).or_insert(m);
+        }
+    }
 
     let mut avatar_uids = std::collections::HashSet::new();
     for m in &messages_to_process {
@@ -1283,7 +1306,7 @@ pub async fn attach_metadata(
                                     deleted_at: reply_msg.deleted_at,
                                     mention_source: None,
                                     mention_uids: None,
-                                    forwarded_from_message_id: None,
+                                    forwarded_from_message_id: reply_msg.forwarded_from_message_id,
                                 },
                                 &reply_sticker_emoji_map,
                                 &user_avatars,

--- a/backend/src/handlers/invites.rs
+++ b/backend/src/handlers/invites.rs
@@ -368,6 +368,7 @@ async fn post_send_invite_message(
             client_generated_id: body.client_generated_id,
             attachment_ids: vec![],
             publish_immediately: true,
+            forwarded_from_message_id: None,
         },
     )
     .await?;
@@ -725,6 +726,7 @@ async fn post_redeem_invite(
                 client_generated_id: uuid::Uuid::new_v4().to_string(),
                 attachment_ids: vec![],
                 publish_immediately: true,
+                forwarded_from_message_id: None,
             },
         )
         .await

--- a/backend/src/handlers/members.rs
+++ b/backend/src/handlers/members.rs
@@ -290,6 +290,7 @@ async fn post_add_member(
                 client_generated_id: uuid::Uuid::new_v4().to_string(),
                 attachment_ids: vec![],
                 publish_immediately: true,
+                forwarded_from_message_id: None,
             },
         )
         .await
@@ -420,6 +421,7 @@ async fn delete_remove_member(
                 client_generated_id: uuid::Uuid::new_v4().to_string(),
                 attachment_ids: vec![],
                 publish_immediately: true,
+                forwarded_from_message_id: None,
             },
         )
         .await

--- a/backend/src/handlers/pins.rs
+++ b/backend/src/handlers/pins.rs
@@ -225,6 +225,7 @@ async fn create_pin(
                 client_generated_id: Uuid::new_v4().to_string(),
                 attachment_ids: vec![],
                 publish_immediately: true,
+                forwarded_from_message_id: None,
             },
         )
         .await
@@ -302,6 +303,7 @@ async fn delete_pin(
                 client_generated_id: Uuid::new_v4().to_string(),
                 attachment_ids: vec![],
                 publish_immediately: true,
+                forwarded_from_message_id: None,
             },
         )
         .await

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -519,6 +519,7 @@ pub struct Message {
     pub sticker_id: Option<i64>,
     pub is_published: bool,
     pub transcode_status: TranscodeStatus,
+    pub forwarded_from_message_id: Option<i64>,
 }
 
 #[derive(Debug, Clone, Insertable)]
@@ -541,6 +542,7 @@ pub struct NewMessage {
     pub sticker_id: Option<i64>,
     pub is_published: bool,
     pub transcode_status: TranscodeStatus,
+    pub forwarded_from_message_id: Option<i64>,
 }
 
 #[derive(Debug, Clone, Queryable, Selectable, Insertable)]

--- a/backend/src/schema/primary.rs
+++ b/backend/src/schema/primary.rs
@@ -198,6 +198,7 @@ diesel::table! {
         sticker_id -> Nullable<Int8>,
         is_published -> Bool,
         transcode_status -> TranscodeStatus,
+        forwarded_from_message_id -> Nullable<Int8>,
     }
 }
 

--- a/backend/src/services/message_search/mod.rs
+++ b/backend/src/services/message_search/mod.rs
@@ -853,6 +853,7 @@ mod tests {
             sticker_id: None,
             is_published: true,
             transcode_status: TranscodeStatus::None,
+            forwarded_from_message_id: None,
         }
     }
 

--- a/backend/src/services/saved_messages.rs
+++ b/backend/src/services/saved_messages.rs
@@ -574,6 +574,7 @@ mod tests {
             sticker_id: None,
             is_published: true,
             transcode_status: TranscodeStatus::None,
+            forwarded_from_message_id: None,
         }
     }
 

--- a/backend/src/services/threads.rs
+++ b/backend/src/services/threads.rs
@@ -907,10 +907,12 @@ pub fn enrich_thread_list(
                     deleted_at: None,
                     mention_source: None,
                     mention_uids: mention_uids_per_reply.get(&lr.reply_root_id).cloned(),
+                    forwarded_from_message_id: None,
                 },
                 &sticker_emoji_map,
                 &user_avatars,
                 &user_profiles,
+                &HashMap::new(),
             ),
         );
     }
@@ -946,10 +948,12 @@ pub fn enrich_thread_list(
                     deleted_at: root_msg.deleted_at,
                     mention_source: None,
                     mention_uids: mention_uids_per_root.get(&root_msg.id).cloned(),
+                    forwarded_from_message_id: None,
                 },
                 &sticker_emoji_map,
                 &user_avatars,
                 &user_profiles,
+                &HashMap::new(),
             );
             Some(ThreadListItem {
                 chat_id: row.chat_id,

--- a/wetty-chat-mobile/locales/en/messages.po
+++ b/wetty-chat-mobile/locales/en/messages.po
@@ -16,6 +16,10 @@ msgstr ""
 msgid "[Deleted]"
 msgstr "[Deleted]"
 
+#. placeholder {0}: thread.replyCount
+msgid "{0} replies"
+msgstr "{0} replies"
+
 msgid "{count} attachments"
 msgstr "{count} attachments"
 
@@ -387,6 +391,9 @@ msgstr "Failed to delete sticker pack"
 msgid "Failed to edit message"
 msgstr "Failed to edit message"
 
+msgid "Failed to forward message"
+msgstr "Failed to forward message"
+
 msgid "Failed to jump to message"
 msgstr "Failed to jump to message"
 
@@ -521,6 +528,16 @@ msgstr "File is too large. Maximum sticker size is 10 MB."
 
 msgid "Forever"
 msgstr "Forever"
+
+msgid "Forward"
+msgstr "Forward"
+
+msgid "Forward to"
+msgstr "Forward to"
+
+#. placeholder {0}: forwardedFrom.sender.name ?? 'Unknown'
+msgid "Forwarded from {0}"
+msgstr "Forwarded from {0}"
 
 msgid "General"
 msgstr "General"
@@ -686,6 +703,9 @@ msgstr "Message"
 msgid "Message cannot be empty"
 msgstr "Message cannot be empty"
 
+msgid "Message forwarded"
+msgstr "Message forwarded"
+
 msgid "Message not found"
 msgstr "Message not found"
 
@@ -739,6 +759,9 @@ msgstr "No archived conversations"
 
 msgid "No archived threads"
 msgstr "No archived threads"
+
+msgid "No chats available"
+msgstr "No chats available"
 
 msgid "No chats yet"
 msgstr "No chats yet"
@@ -1043,6 +1066,9 @@ msgstr "Search"
 
 msgid "Search by username or UID"
 msgstr "Search by username or UID"
+
+msgid "Search chats"
+msgstr "Search chats"
 
 msgid "Search emoji"
 msgstr "Search emoji"

--- a/wetty-chat-mobile/locales/en/messages.po
+++ b/wetty-chat-mobile/locales/en/messages.po
@@ -17,8 +17,8 @@ msgid "[Deleted]"
 msgstr "[Deleted]"
 
 #. placeholder {0}: thread.replyCount
-msgid "{0} replies"
-msgstr "{0} replies"
+msgid "{0, plural, one {# reply} other {# replies}}"
+msgstr "{0, plural, one {# reply} other {# replies}}"
 
 msgid "{count} attachments"
 msgstr "{count} attachments"
@@ -535,7 +535,7 @@ msgstr "Forward"
 msgid "Forward to"
 msgstr "Forward to"
 
-#. placeholder {0}: forwardedFrom.sender.name ?? 'Unknown'
+#. placeholder {0}: name || t`Unknown`
 msgid "Forwarded from {0}"
 msgstr "Forwarded from {0}"
 

--- a/wetty-chat-mobile/locales/zh-CN/messages.po
+++ b/wetty-chat-mobile/locales/zh-CN/messages.po
@@ -17,8 +17,8 @@ msgid "[Deleted]"
 msgstr "[已删除]"
 
 #. placeholder {0}: thread.replyCount
-msgid "{0} replies"
-msgstr "{0} 条回复"
+msgid "{0, plural, one {# reply} other {# replies}}"
+msgstr "{0, plural, one {# 条回复} other {# 条回复}}"
 
 msgid "{count} attachments"
 msgstr "{count} 个附件"
@@ -535,7 +535,7 @@ msgstr "转发"
 msgid "Forward to"
 msgstr "转发到"
 
-#. placeholder {0}: forwardedFrom.sender.name ?? 'Unknown'
+#. placeholder {0}: name || t`Unknown`
 msgid "Forwarded from {0}"
 msgstr "转发自 {0}"
 

--- a/wetty-chat-mobile/locales/zh-CN/messages.po
+++ b/wetty-chat-mobile/locales/zh-CN/messages.po
@@ -16,6 +16,10 @@ msgstr ""
 msgid "[Deleted]"
 msgstr "[已删除]"
 
+#. placeholder {0}: thread.replyCount
+msgid "{0} replies"
+msgstr "{0} 条回复"
+
 msgid "{count} attachments"
 msgstr "{count} 个附件"
 
@@ -387,6 +391,9 @@ msgstr "删除贴纸包失败"
 msgid "Failed to edit message"
 msgstr "编辑消息失败"
 
+msgid "Failed to forward message"
+msgstr "转发消息失败"
+
 msgid "Failed to jump to message"
 msgstr "跳转到消息失败"
 
@@ -521,6 +528,16 @@ msgstr "文件过大。贴纸文件大小上限为 10 MB。"
 
 msgid "Forever"
 msgstr "永久"
+
+msgid "Forward"
+msgstr "转发"
+
+msgid "Forward to"
+msgstr "转发到"
+
+#. placeholder {0}: forwardedFrom.sender.name ?? 'Unknown'
+msgid "Forwarded from {0}"
+msgstr "转发自 {0}"
 
 msgid "General"
 msgstr "通用"
@@ -686,6 +703,9 @@ msgstr "消息"
 msgid "Message cannot be empty"
 msgstr "消息不能为空"
 
+msgid "Message forwarded"
+msgstr "消息已转发"
+
 msgid "Message not found"
 msgstr "未找到消息"
 
@@ -739,6 +759,9 @@ msgstr "没有已归档会话"
 
 msgid "No archived threads"
 msgstr "没有已归档话题"
+
+msgid "No chats available"
+msgstr "暂无可用聊天"
 
 msgid "No chats yet"
 msgstr "暂无聊天"
@@ -1043,6 +1066,9 @@ msgstr "搜索"
 
 msgid "Search by username or UID"
 msgstr "按用户名或 UID 搜索"
+
+msgid "Search chats"
+msgstr "搜索聊天"
 
 msgid "Search emoji"
 msgstr "搜索表情"

--- a/wetty-chat-mobile/locales/zh-TW/messages.po
+++ b/wetty-chat-mobile/locales/zh-TW/messages.po
@@ -17,8 +17,8 @@ msgid "[Deleted]"
 msgstr "[已刪除]"
 
 #. placeholder {0}: thread.replyCount
-msgid "{0} replies"
-msgstr "{0} 則回覆"
+msgid "{0, plural, one {# reply} other {# replies}}"
+msgstr "{0, plural, one {# 則回覆} other {# 則回覆}}"
 
 msgid "{count} attachments"
 msgstr "{count} 個附件"
@@ -535,7 +535,7 @@ msgstr "轉發"
 msgid "Forward to"
 msgstr "轉發到"
 
-#. placeholder {0}: forwardedFrom.sender.name ?? 'Unknown'
+#. placeholder {0}: name || t`Unknown`
 msgid "Forwarded from {0}"
 msgstr "轉發自 {0}"
 

--- a/wetty-chat-mobile/locales/zh-TW/messages.po
+++ b/wetty-chat-mobile/locales/zh-TW/messages.po
@@ -16,6 +16,10 @@ msgstr ""
 msgid "[Deleted]"
 msgstr "[已刪除]"
 
+#. placeholder {0}: thread.replyCount
+msgid "{0} replies"
+msgstr "{0} 則回覆"
+
 msgid "{count} attachments"
 msgstr "{count} 個附件"
 
@@ -387,6 +391,9 @@ msgstr "刪除貼紙包失敗"
 msgid "Failed to edit message"
 msgstr "編輯訊息失敗"
 
+msgid "Failed to forward message"
+msgstr "轉發訊息失敗"
+
 msgid "Failed to jump to message"
 msgstr "跳轉到訊息失敗"
 
@@ -521,6 +528,16 @@ msgstr "檔案過大。貼圖檔案大小上限為 10 MB。"
 
 msgid "Forever"
 msgstr "永久"
+
+msgid "Forward"
+msgstr "轉發"
+
+msgid "Forward to"
+msgstr "轉發到"
+
+#. placeholder {0}: forwardedFrom.sender.name ?? 'Unknown'
+msgid "Forwarded from {0}"
+msgstr "轉發自 {0}"
 
 msgid "General"
 msgstr "一般"
@@ -686,6 +703,9 @@ msgstr "訊息"
 msgid "Message cannot be empty"
 msgstr "訊息不能為空"
 
+msgid "Message forwarded"
+msgstr "訊息已轉發"
+
 msgid "Message not found"
 msgstr "找不到訊息"
 
@@ -739,6 +759,9 @@ msgstr "沒有已封存對話"
 
 msgid "No archived threads"
 msgstr "沒有已封存話題"
+
+msgid "No chats available"
+msgstr "暫無可用聊天"
 
 msgid "No chats yet"
 msgstr "暫無聊天"
@@ -1043,6 +1066,9 @@ msgstr "搜尋"
 
 msgid "Search by username or UID"
 msgstr "依使用者名稱或 UID 搜尋"
+
+msgid "Search chats"
+msgstr "搜尋聊天"
 
 msgid "Search emoji"
 msgstr "搜尋表情"

--- a/wetty-chat-mobile/src/api/messages.ts
+++ b/wetty-chat-mobile/src/api/messages.ts
@@ -34,6 +34,7 @@ export interface MessagePreview {
   isDeleted: boolean;
   attachments?: Attachment[];
   mentions?: MentionInfo[] | null;
+  forwardedFromName?: string | null;
 }
 
 export type ReplyToMessage = MessagePreview;
@@ -101,6 +102,12 @@ export interface MessageResponse {
   attachments?: Attachment[];
   reactions?: ReactionSummary[];
   mentions?: MentionInfo[];
+  forwardedFrom?: {
+    sender: User;
+    originalChatId: string;
+    originalMessageId: string;
+    originalReplyTo?: ReplyToMessage;
+  } | null;
 }
 
 export function toMessagePreview(message: MessageResponse): MessagePreview {
@@ -217,6 +224,18 @@ export function updateMessage(
   body: UpdateMessageBody,
 ): Promise<AxiosResponse<MessageResponse>> {
   return apiClient.patch(`/chats/${chatId}/messages/${messageId}`, body);
+}
+
+export function forwardMessage(
+  targetChatId: string | number,
+  messageId: string,
+  body: {
+    sourceChatId: string | number;
+    clientGeneratedId: string;
+    threadId?: string | number;
+  },
+): Promise<AxiosResponse<MessageResponse>> {
+  return apiClient.post(`/chats/${targetChatId}/messages/${messageId}/forward`, body);
 }
 
 export function deleteMessage(chatId: string | number, messageId: string): Promise<AxiosResponse<void>> {

--- a/wetty-chat-mobile/src/components/chat/compose/ComposeContextBanner.tsx
+++ b/wetty-chat-mobile/src/components/chat/compose/ComposeContextBanner.tsx
@@ -1,11 +1,12 @@
 import { IonIcon } from '@ionic/react';
 import { t } from '@lingui/core/macro';
-import { arrowRedoOutline, closeCircle } from 'ionicons/icons';
+import { closeCircle } from 'ionicons/icons';
 import { useSelector } from 'react-redux';
 import { selectEffectiveLocale } from '@/store/settingsSlice';
 import { useChatContext } from '@/components/chat/messages/ChatContext';
 import { formatMessagePreview, getNotificationPreviewLabels } from '@/utils/messagePreview';
 import type { EditingMessage, ReplyTo } from './types';
+import { ForwardedLabel } from '@/components/chat/messages/ForwardedLabel';
 import styles from './MessageComposeBar.module.scss';
 
 interface ComposeContextBannerProps {
@@ -46,10 +47,7 @@ export function ComposeContextBanner({ editing, replyTo, onCancelEdit, onCancelR
     <div className={styles.replyPreview}>
       <div className={`${styles.replyText} ${styles.replyPreviewTappable}`} onClick={handleJumpToReply}>
         {replyTo.forwardedFromName ? (
-          <span className={styles.forwardedLabel}>
-            <IonIcon icon={arrowRedoOutline} className={styles.forwardedIcon} />
-            {t`Forwarded from ${replyTo.forwardedFromName}`}
-          </span>
+          <ForwardedLabel name={replyTo.forwardedFromName} as="span" />
         ) : (
           <span className={styles.replyUsername}>{t`Replying to ${replyTo.username}`}</span>
         )}

--- a/wetty-chat-mobile/src/components/chat/compose/ComposeContextBanner.tsx
+++ b/wetty-chat-mobile/src/components/chat/compose/ComposeContextBanner.tsx
@@ -1,6 +1,6 @@
 import { IonIcon } from '@ionic/react';
 import { t } from '@lingui/core/macro';
-import { closeCircle } from 'ionicons/icons';
+import { arrowRedoOutline, closeCircle } from 'ionicons/icons';
 import { useSelector } from 'react-redux';
 import { selectEffectiveLocale } from '@/store/settingsSlice';
 import { useChatContext } from '@/components/chat/messages/ChatContext';
@@ -45,7 +45,14 @@ export function ComposeContextBanner({ editing, replyTo, onCancelEdit, onCancelR
   return (
     <div className={styles.replyPreview}>
       <div className={`${styles.replyText} ${styles.replyPreviewTappable}`} onClick={handleJumpToReply}>
-        <span className={styles.replyUsername}>{t`Replying to ${replyTo.username}`}</span>
+        {replyTo.forwardedFromName ? (
+          <span className={styles.forwardedLabel}>
+            <IonIcon icon={arrowRedoOutline} className={styles.forwardedIcon} />
+            {t`Forwarded from ${replyTo.forwardedFromName}`}
+          </span>
+        ) : (
+          <span className={styles.replyUsername}>{t`Replying to ${replyTo.username}`}</span>
+        )}
         <span className={styles.replySnippet}>
           {formatMessagePreview(replyTo, getNotificationPreviewLabels(locale))}
         </span>

--- a/wetty-chat-mobile/src/components/chat/compose/MessageComposeBar.module.scss
+++ b/wetty-chat-mobile/src/components/chat/compose/MessageComposeBar.module.scss
@@ -67,6 +67,21 @@
   color: var(--ion-color-primary);
 }
 
+.forwardedIcon {
+  font-size: 14px;
+  margin-right: 4px;
+  vertical-align: -2px;
+}
+
+.forwardedLabel {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.75rem;
+  font-style: italic;
+  color: var(--ion-color-medium);
+}
+
 .replySnippet {
   font-size: 12px;
   color: var(--ion-text-color-step-600, #666);

--- a/wetty-chat-mobile/src/components/chat/compose/MessageComposeBar.module.scss
+++ b/wetty-chat-mobile/src/components/chat/compose/MessageComposeBar.module.scss
@@ -67,21 +67,6 @@
   color: var(--ion-color-primary);
 }
 
-.forwardedIcon {
-  font-size: 14px;
-  margin-right: 4px;
-  vertical-align: -2px;
-}
-
-.forwardedLabel {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  font-size: 0.75rem;
-  font-style: italic;
-  color: var(--ion-color-medium);
-}
-
 .replySnippet {
   font-size: 12px;
   color: var(--ion-text-color-step-600, #666);

--- a/wetty-chat-mobile/src/components/chat/compose/types.ts
+++ b/wetty-chat-mobile/src/components/chat/compose/types.ts
@@ -11,6 +11,7 @@ export interface ReplyTo {
   attachments?: Attachment[];
   isDeleted?: boolean;
   mentions?: MentionInfo[];
+  forwardedFromName?: string | null;
 }
 
 export interface EditingMessage {

--- a/wetty-chat-mobile/src/components/chat/messages/ChatBubble.module.scss
+++ b/wetty-chat-mobile/src/components/chat/messages/ChatBubble.module.scss
@@ -476,6 +476,21 @@
   }
 }
 
+.forwardedLabel {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.75rem;
+  font-style: italic;
+  color: var(--ion-color-medium);
+  margin-bottom: 2px;
+}
+
+.forwardedIcon {
+  font-size: 0.8rem;
+  color: var(--ion-color-medium);
+}
+
 .avatarSpacer {
   width: var(--avatar-size);
   flex-shrink: 0;

--- a/wetty-chat-mobile/src/components/chat/messages/ChatBubble.module.scss
+++ b/wetty-chat-mobile/src/components/chat/messages/ChatBubble.module.scss
@@ -476,21 +476,6 @@
   }
 }
 
-.forwardedLabel {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  font-size: 0.75rem;
-  font-style: italic;
-  color: var(--ion-color-medium);
-  margin-bottom: 2px;
-}
-
-.forwardedIcon {
-  font-size: 0.8rem;
-  color: var(--ion-color-medium);
-}
-
 .avatarSpacer {
   width: var(--avatar-size);
   flex-shrink: 0;

--- a/wetty-chat-mobile/src/components/chat/messages/ChatBubbleBase.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/ChatBubbleBase.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState, type CSSProperties, type HTMLAttributes, type Ref } from 'react';
 import { IonIcon } from '@ionic/react';
 import {
+  arrowRedoOutline,
   chatbubbles,
   checkmarkCircle,
   checkmarkCircleOutline,
@@ -14,7 +15,7 @@ import styles from './ChatBubble.module.scss';
 import { HoverReplyButton } from './HoverReplyButton';
 import reactionStyles from './ReactionPill.module.scss';
 import { formatTime } from '@/utils/formatTime';
-import type { Attachment, MentionInfo, ReactionSummary, UserGroupTagInfo } from '@/api/messages';
+import type { Attachment, MentionInfo, ReplyToMessage, ReactionSummary, UserGroupTagInfo } from '@/api/messages';
 import { ImageViewer } from '@/components/chat/messages/media/ImageViewer';
 import { type PreviewMessage } from '@/utils/messagePreview';
 import { selectChatFontSizeStyle } from '@/store/settingsSlice';
@@ -97,6 +98,7 @@ export interface ChatBubbleBaseProps {
   replyTo?: {
     senderName: string;
     preview: PreviewMessage;
+    forwardedFromName?: string | null;
   };
   timestamp?: string;
   edited?: boolean;
@@ -113,6 +115,10 @@ export interface ChatBubbleBaseProps {
   bubbleProps?: BubblePropsOverride;
   bubbleRef?: Ref<HTMLDivElement>;
   mentions?: MentionInfo[];
+  forwardedFrom?: {
+    sender: { name: string | null };
+    originalReplyTo?: ReplyToMessage;
+  } | null;
   currentUserUid?: number | null;
   onMentionClick?: (uid: number) => void;
   showDroplet?: boolean;
@@ -147,6 +153,7 @@ export function ChatBubbleBase({
   bubbleProps,
   bubbleRef,
   mentions,
+  forwardedFrom,
   currentUserUid,
   onMentionClick,
   showDroplet: showDropletProp,
@@ -160,7 +167,7 @@ export function ChatBubbleBase({
   const otherAttachments = attachments?.filter((att) => !(isImageAttachment(att) || isVideoAttachment(att))) ?? [];
   const { className: bubbleClassName, style: bubbleStyle, ...bubbleRestProps } = bubbleProps ?? {};
 
-  const hasTopContent = showName || replyTo;
+  const hasTopContent = showName || replyTo || !!forwardedFrom;
   const hasBottomContent = message && message.trim() !== '';
   const isMediaOnly = imageAttachments.length > 0 && !hasBottomContent && otherAttachments.length === 0;
   const showDroplet = (showDropletProp ?? (showAvatar || layout === 'bubble-only')) && !isMediaOnly;
@@ -408,6 +415,22 @@ export function ChatBubbleBase({
               <IonIcon icon={maleOutline} className={`${styles.gender} ${styles.gender1}`} />
             ))}
         </div>
+      )}
+      {forwardedFrom && (
+        <div className={styles.forwardedLabel}>
+          <IonIcon icon={arrowRedoOutline} className={styles.forwardedIcon} />
+          <span>{t`Forwarded from ${forwardedFrom.sender.name ?? t`Unknown`}`}</span>
+        </div>
+      )}
+      {forwardedFrom?.originalReplyTo && (
+        <ReplyPreview
+          replyTo={{
+            senderName: forwardedFrom.originalReplyTo.sender.name ?? t`Unknown`,
+            preview: forwardedFrom.originalReplyTo,
+          }}
+          isSent={isSent}
+          interactive={false}
+        />
       )}
       {replyTo && <ReplyPreview replyTo={replyTo} isSent={isSent} interactive={interactive} onReplyTap={onReplyTap} />}
       {imageAttachments.length > 0 && (

--- a/wetty-chat-mobile/src/components/chat/messages/ChatBubbleBase.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/ChatBubbleBase.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState, type CSSProperties, type HTMLAttributes, type Ref } from 'react';
 import { IonIcon } from '@ionic/react';
 import {
-  arrowRedoOutline,
   chatbubbles,
   checkmarkCircle,
   checkmarkCircleOutline,
@@ -38,6 +37,7 @@ import {
   getChatBubbleMaxWidth,
 } from '@/utils/chatTextMeasure';
 
+import { ForwardedLabel } from './ForwardedLabel';
 function isImageAttachment(attachment: Attachment) {
   return (
     attachment.kind.startsWith('image/') ||
@@ -416,12 +416,7 @@ export function ChatBubbleBase({
             ))}
         </div>
       )}
-      {forwardedFrom && (
-        <div className={styles.forwardedLabel}>
-          <IonIcon icon={arrowRedoOutline} className={styles.forwardedIcon} />
-          <span>{t`Forwarded from ${forwardedFrom.sender.name ?? t`Unknown`}`}</span>
-        </div>
-      )}
+      {forwardedFrom && <ForwardedLabel name={forwardedFrom.sender.name} />}
       {forwardedFrom?.originalReplyTo && (
         <ReplyPreview
           replyTo={{

--- a/wetty-chat-mobile/src/components/chat/messages/ChatBubbleBase.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/ChatBubbleBase.tsx
@@ -422,6 +422,7 @@ export function ChatBubbleBase({
           replyTo={{
             senderName: forwardedFrom.originalReplyTo.sender.name ?? t`Unknown`,
             preview: forwardedFrom.originalReplyTo,
+            forwardedFromName: forwardedFrom.originalReplyTo.forwardedFromName,
           }}
           isSent={isSent}
           interactive={false}

--- a/wetty-chat-mobile/src/components/chat/messages/ChatMessageRow.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/ChatMessageRow.tsx
@@ -147,11 +147,13 @@ function MessageBubble({
     onAvatarClick: () => onAvatarClick(msg.sender),
     isLastInGroup,
     isConfirmed: !msg.id.startsWith('cg_'),
+    forwardedFrom: msg.forwardedFrom ?? undefined,
     bubbleProps: { 'data-message-id': msg.id, 'data-bubble-row': '' } as BubblePropsOverride,
     replyTo: replyToMessage
       ? {
           senderName: replyToMessage.sender.name ?? `User ${replyToMessage.sender.uid}`,
           preview: replyToMessage,
+          forwardedFromName: replyToMessage.forwardedFromName,
         }
       : undefined,
   } as const;

--- a/wetty-chat-mobile/src/components/chat/messages/ForwardMessageModal.module.scss
+++ b/wetty-chat-mobile/src/components/chat/messages/ForwardMessageModal.module.scss
@@ -1,0 +1,15 @@
+.spinnerContainer {
+  display: flex;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.threadReplyCount {
+  font-size: 0.85em;
+  opacity: 0.7;
+}
+
+.threadReplyIcon {
+  vertical-align: middle;
+  margin-right: 4px;
+}

--- a/wetty-chat-mobile/src/components/chat/messages/ForwardMessageModal.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/ForwardMessageModal.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-
+import { useForwardTargetList } from './useForwardTargetList';
 import {
   IonButton,
   IonButtons,
@@ -19,14 +19,17 @@ import {
 import { chatbubbleOutline } from 'ionicons/icons';
 import { Plural, Trans } from '@lingui/react/macro';
 import { t } from '@lingui/core/macro';
-import { getChats, type ChatListEntry } from '@/api/chats';
+import type { ChatListEntry } from '@/api/chats';
 import { UserAvatar } from '@/components/UserAvatar';
 import { OverlayAvatar } from '@/components/OverlayAvatar';
 import { getChatDisplayName } from '@/utils/chatDisplay';
 import { forwardMessage, type MessageResponse } from '@/api/messages';
-import { getThreads, type ThreadListItem } from '@/api/threads';
+import type { ThreadListItem } from '@/api/threads';
+
 import { useIsDesktop } from '@/hooks/platformHooks';
 import styles from './ForwardMessageModal.module.scss';
+
+const THREAD_PREVIEW_MAX_LENGTH = 60;
 
 interface ForwardMessageModalProps {
   isOpen: boolean;
@@ -42,11 +45,9 @@ type UnifiedItem =
 export function ForwardMessageModal({ isOpen, onClose, message, sourceChatId }: ForwardMessageModalProps) {
   const [presentToast] = useIonToast();
   const [forwarding, setForwarding] = useState(false);
-  const [chats, setChats] = useState<ChatListEntry[]>([]);
-  const [threads, setThreads] = useState<ThreadListItem[]>([]);
-  const [loading, setLoading] = useState(false);
   const [searchText, setSearchText] = useState('');
   const isDesktop = useIsDesktop();
+  const { chats, threads, loading, error: fetchError } = useForwardTargetList(isOpen);
 
   const showToast = useCallback(
     (msg: string, duration = 3000) => {
@@ -55,37 +56,16 @@ export function ForwardMessageModal({ isOpen, onClose, message, sourceChatId }: 
     [presentToast],
   );
 
-  // Fetch non-archived chats and subscribed threads when modal opens.
+  // Show toast when fetch fails.
   useEffect(() => {
-    if (!isOpen) {
-      setChats([]);
-      setThreads([]);
-      setSearchText('');
-      return;
+    if (fetchError) {
+      showToast(fetchError);
     }
+  }, [fetchError, showToast]);
 
-    let cancelled = false;
-    setLoading(true);
-
-    Promise.all([getChats({ archived: false }), getThreads({ limit: 50, archived: false })])
-      .then(([chatRes, threadRes]) => {
-        if (!cancelled) {
-          setChats(chatRes.data.chats);
-          setThreads(threadRes.data.threads);
-        }
-      })
-      .catch((err) => {
-        console.warn('Failed to load chats for forward modal', err);
-      })
-      .finally(() => {
-        if (!cancelled) {
-          setLoading(false);
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
+  // Reset search when modal closes.
+  useEffect(() => {
+    if (!isOpen) setSearchText('');
   }, [isOpen]);
 
   // Merge chats and threads into a single sorted list.
@@ -143,8 +123,8 @@ export function ForwardMessageModal({ isOpen, onClose, message, sourceChatId }: 
         showToast(t`Message forwarded`, 2000);
         onClose();
       } catch (err: unknown) {
-        const msg = err instanceof Error ? err.message : t`Failed to forward message`;
-        showToast(msg);
+        const errorMsg = err instanceof Error ? err.message : t`Failed to forward message`;
+        showToast(errorMsg);
       } finally {
         setForwarding(false);
       }
@@ -227,7 +207,9 @@ export function ForwardMessageModal({ isOpen, onClose, message, sourceChatId }: 
                   <IonLabel>
                     <h3>{getChatDisplayName(thread.chatId, thread.chatName)}</h3>
                     <p>
-                      {thread.threadRootMessage.message ? thread.threadRootMessage.message.slice(0, 60) : t`Thread`}
+                      {thread.threadRootMessage.message
+                        ? thread.threadRootMessage.message.slice(0, THREAD_PREVIEW_MAX_LENGTH)
+                        : t`Thread`}
                     </p>
                     <p className={styles.threadReplyCount}>
                       <IonIcon icon={chatbubbleOutline} className={styles.threadReplyIcon} />

--- a/wetty-chat-mobile/src/components/chat/messages/ForwardMessageModal.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/ForwardMessageModal.tsx
@@ -1,0 +1,245 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import {
+  IonButton,
+  IonButtons,
+  IonContent,
+  IonHeader,
+  IonIcon,
+  IonItem,
+  IonLabel,
+  IonList,
+  IonModal,
+  IonSearchbar,
+  IonSpinner,
+  IonTitle,
+  IonToolbar,
+  useIonToast,
+} from '@ionic/react';
+import { chatbubbleOutline } from 'ionicons/icons';
+import { Plural, Trans } from '@lingui/react/macro';
+import { t } from '@lingui/core/macro';
+import { getChats, type ChatListEntry } from '@/api/chats';
+import { UserAvatar } from '@/components/UserAvatar';
+import { OverlayAvatar } from '@/components/OverlayAvatar';
+import { getChatDisplayName } from '@/utils/chatDisplay';
+import { forwardMessage, type MessageResponse } from '@/api/messages';
+import { getThreads, type ThreadListItem } from '@/api/threads';
+import { useIsDesktop } from '@/hooks/platformHooks';
+import styles from './ForwardMessageModal.module.scss';
+
+interface ForwardMessageModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  message: MessageResponse;
+  sourceChatId: string;
+}
+
+type UnifiedItem =
+  | { type: 'group'; item: ChatListEntry; sortTime: number }
+  | { type: 'thread'; item: ThreadListItem; sortTime: number };
+
+export function ForwardMessageModal({ isOpen, onClose, message, sourceChatId }: ForwardMessageModalProps) {
+  const [presentToast] = useIonToast();
+  const [forwarding, setForwarding] = useState(false);
+  const [chats, setChats] = useState<ChatListEntry[]>([]);
+  const [threads, setThreads] = useState<ThreadListItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [searchText, setSearchText] = useState('');
+  const isDesktop = useIsDesktop();
+
+  const showToast = useCallback(
+    (msg: string, duration = 3000) => {
+      presentToast({ message: msg, duration, position: 'bottom', cssClass: 'toast-center' });
+    },
+    [presentToast],
+  );
+
+  // Fetch non-archived chats and subscribed threads when modal opens.
+  useEffect(() => {
+    if (!isOpen) {
+      setChats([]);
+      setThreads([]);
+      setSearchText('');
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+
+    Promise.all([getChats({ archived: false }), getThreads({ limit: 50, archived: false })])
+      .then(([chatRes, threadRes]) => {
+        if (!cancelled) {
+          setChats(chatRes.data.chats);
+          setThreads(threadRes.data.threads);
+        }
+      })
+      .catch((err) => {
+        console.warn('Failed to load chats for forward modal', err);
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen]);
+
+  // Merge chats and threads into a single sorted list.
+  const mergedItems = useMemo((): UnifiedItem[] => {
+    const items: UnifiedItem[] = [];
+
+    for (const chat of chats) {
+      items.push({
+        type: 'group',
+        item: chat,
+        sortTime: chat.lastMessageAt ? new Date(chat.lastMessageAt).getTime() : 0,
+      });
+    }
+
+    for (const thread of threads) {
+      items.push({
+        type: 'thread',
+        item: thread,
+        sortTime: thread.lastReplyAt ? new Date(thread.lastReplyAt).getTime() : 0,
+      });
+    }
+
+    // Sort all items by most recent activity.
+    items.sort((a, b) => b.sortTime - a.sortTime);
+
+    return items;
+  }, [chats, threads]);
+
+  // Filter by search text.
+  const filteredItems = useMemo(() => {
+    if (!searchText.trim()) return mergedItems;
+    const q = searchText.toLowerCase();
+
+    return mergedItems.filter((item) => {
+      if (item.type === 'group') {
+        return (item.item.name ?? '').toLowerCase().includes(q);
+      }
+      return (
+        item.item.chatName.toLowerCase().includes(q) ||
+        (item.item.threadRootMessage.message ?? '').toLowerCase().includes(q)
+      );
+    });
+  }, [mergedItems, searchText]);
+
+  const handleSelect = useCallback(
+    async (chatId: string, threadId?: string) => {
+      if (forwarding) return;
+      setForwarding(true);
+      try {
+        await forwardMessage(chatId, message.id, {
+          sourceChatId,
+          clientGeneratedId: `cg_${Date.now()}_${Math.random().toString(36).slice(2)}`,
+          ...(threadId !== undefined ? { threadId } : {}),
+        });
+        showToast(t`Message forwarded`, 2000);
+        onClose();
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : t`Failed to forward message`;
+        showToast(msg);
+      } finally {
+        setForwarding(false);
+      }
+    },
+    [forwarding, message.id, onClose, showToast, sourceChatId],
+  );
+
+  return (
+    <IonModal
+      isOpen={isOpen}
+      onDidDismiss={onClose}
+      {...(!isDesktop ? { initialBreakpoint: 0.5, breakpoints: [0, 0.5, 0.9] } : {})}
+    >
+      <IonHeader>
+        <IonToolbar>
+          <IonTitle>
+            <Trans>Forward to</Trans>
+          </IonTitle>
+          <IonButtons slot="end">
+            <IonButton onClick={onClose}>{t`Cancel`}</IonButton>
+          </IonButtons>
+        </IonToolbar>
+      </IonHeader>
+      <IonContent color="light">
+        <IonSearchbar
+          placeholder={t`Search chats`}
+          value={searchText}
+          onIonInput={(e) => setSearchText(e.detail.value ?? '')}
+          debounce={200}
+        />
+
+        {loading ? (
+          <div className={styles.spinnerContainer}>
+            <IonSpinner />
+          </div>
+        ) : filteredItems.length === 0 ? (
+          <IonList>
+            <IonItem>
+              <IonLabel>
+                <p>
+                  <Trans>No chats available</Trans>
+                </p>
+              </IonLabel>
+            </IonItem>
+          </IonList>
+        ) : (
+          <IonList>
+            {filteredItems.map((unified) => {
+              if (unified.type === 'group') {
+                const chat = unified.item;
+                return (
+                  <IonItem key={`group-${chat.id}`} button disabled={forwarding} onClick={() => handleSelect(chat.id)}>
+                    <span slot="start">
+                      <UserAvatar name={getChatDisplayName(chat.id, chat.name)} avatarUrl={chat.avatar} size={40} />
+                    </span>
+                    <IonLabel>
+                      <h3>{getChatDisplayName(chat.id, chat.name)}</h3>
+                    </IonLabel>
+                  </IonItem>
+                );
+              }
+
+              const thread = unified.item;
+              return (
+                <IonItem
+                  key={`thread-${thread.threadRootMessage.id}`}
+                  button
+                  disabled={forwarding}
+                  onClick={() => handleSelect(thread.chatId, thread.threadRootMessage.id)}
+                >
+                  <span slot="start">
+                    <OverlayAvatar
+                      primaryName={thread.chatName}
+                      primaryAvatarUrl={thread.chatAvatar}
+                      secondaryName={thread.threadRootMessage.sender.name ?? null}
+                      secondaryAvatarUrl={thread.threadRootMessage.sender.avatarUrl ?? null}
+                      size={40}
+                    />
+                  </span>
+                  <IonLabel>
+                    <h3>{getChatDisplayName(thread.chatId, thread.chatName)}</h3>
+                    <p>
+                      {thread.threadRootMessage.message ? thread.threadRootMessage.message.slice(0, 60) : t`Thread`}
+                    </p>
+                    <p className={styles.threadReplyCount}>
+                      <IonIcon icon={chatbubbleOutline} className={styles.threadReplyIcon} />
+                      <Plural value={thread.replyCount} one="# reply" other="# replies" />
+                    </p>
+                  </IonLabel>
+                </IonItem>
+              );
+            })}
+          </IonList>
+        )}
+      </IonContent>
+    </IonModal>
+  );
+}

--- a/wetty-chat-mobile/src/components/chat/messages/ForwardedLabel.module.scss
+++ b/wetty-chat-mobile/src/components/chat/messages/ForwardedLabel.module.scss
@@ -12,3 +12,12 @@
   font-size: 0.8rem;
   color: var(--ion-color-medium);
 }
+
+div.forwardedLabel {
+  color: inherit;
+  opacity: 0.7;
+}
+
+div.forwardedLabel .forwardedIcon {
+  color: inherit;
+}

--- a/wetty-chat-mobile/src/components/chat/messages/ForwardedLabel.module.scss
+++ b/wetty-chat-mobile/src/components/chat/messages/ForwardedLabel.module.scss
@@ -1,0 +1,14 @@
+.forwardedLabel {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.75rem;
+  font-style: italic;
+  color: var(--ion-color-medium);
+  margin-bottom: 2px;
+}
+
+.forwardedIcon {
+  font-size: 0.8rem;
+  color: var(--ion-color-medium);
+}

--- a/wetty-chat-mobile/src/components/chat/messages/ForwardedLabel.test.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/ForwardedLabel.test.tsx
@@ -1,0 +1,41 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import { ForwardedLabel } from './ForwardedLabel';
+
+vi.mock('@lingui/core/macro', () => ({
+  t: (strings: TemplateStringsArray | string, ...values: unknown[]) => {
+    if (typeof strings === 'string') return strings;
+    return strings.reduce((acc, str, i) => acc + str + (values[i] ?? ''), '');
+  },
+}));
+
+vi.mock('@ionic/react', () => ({
+  IonIcon: ({ icon }: { icon: string }) => <span data-icon={icon} />,
+}));
+
+describe('ForwardedLabel', () => {
+  it('renders forwarded label with sender name', () => {
+    const html = renderToStaticMarkup(<ForwardedLabel name="Alice" />);
+    expect(html).toContain('Forwarded from Alice');
+  });
+
+  it('renders forwarded label with Unknown fallback when name is null', () => {
+    const html = renderToStaticMarkup(<ForwardedLabel name={null} />);
+    expect(html).toContain('Forwarded from Unknown');
+  });
+
+  it('renders forwarded label with Unknown fallback when name is undefined', () => {
+    const html = renderToStaticMarkup(<ForwardedLabel name={undefined} />);
+    expect(html).toContain('Forwarded from Unknown');
+  });
+
+  it('renders as div by default', () => {
+    const html = renderToStaticMarkup(<ForwardedLabel name="Alice" />);
+    expect(html).toMatch(/^<div/);
+  });
+
+  it('renders as span when as="span"', () => {
+    const html = renderToStaticMarkup(<ForwardedLabel name="Alice" as="span" />);
+    expect(html).toMatch(/^<span/);
+  });
+});

--- a/wetty-chat-mobile/src/components/chat/messages/ForwardedLabel.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/ForwardedLabel.tsx
@@ -1,5 +1,5 @@
 import { IonIcon } from '@ionic/react';
-import { arrowRedoOutline } from 'ionicons/icons';
+import { arrowRedo } from 'ionicons/icons';
 import { t } from '@lingui/core/macro';
 import styles from './ForwardedLabel.module.scss';
 
@@ -12,7 +12,7 @@ interface ForwardedLabelProps {
 export function ForwardedLabel({ name, as: Tag = 'div' }: ForwardedLabelProps) {
   return (
     <Tag className={styles.forwardedLabel}>
-      <IonIcon icon={arrowRedoOutline} className={styles.forwardedIcon} />
+      <IonIcon icon={arrowRedo} className={styles.forwardedIcon} />
       {t`Forwarded from ${name || t`Unknown`}`}
     </Tag>
   );

--- a/wetty-chat-mobile/src/components/chat/messages/ForwardedLabel.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/ForwardedLabel.tsx
@@ -1,0 +1,19 @@
+import { IonIcon } from '@ionic/react';
+import { arrowRedoOutline } from 'ionicons/icons';
+import { t } from '@lingui/core/macro';
+import styles from './ForwardedLabel.module.scss';
+
+interface ForwardedLabelProps {
+  name: string | null | undefined;
+  /** Use inline variant when rendered inside a <span> context (e.g. compose banner). */
+  as?: 'div' | 'span';
+}
+
+export function ForwardedLabel({ name, as: Tag = 'div' }: ForwardedLabelProps) {
+  return (
+    <Tag className={styles.forwardedLabel}>
+      <IonIcon icon={arrowRedoOutline} className={styles.forwardedIcon} />
+      {t`Forwarded from ${name || t`Unknown`}`}
+    </Tag>
+  );
+}

--- a/wetty-chat-mobile/src/components/chat/messages/MessageOverlay.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/MessageOverlay.tsx
@@ -29,6 +29,7 @@ interface MessageOverlayBaseProps {
   replyTo?: {
     senderName: string;
     preview: PreviewMessage;
+    forwardedFromName?: string | null;
   };
   timestamp?: string;
   edited?: boolean;
@@ -44,6 +45,10 @@ interface MessageOverlayBaseProps {
   };
   onClose: () => void;
   mentions?: MentionInfo[];
+  forwardedFrom?: {
+    sender: { name: string | null };
+    originalReplyTo?: import('@/api/messages').ReplyToMessage;
+  } | null;
   currentUserUid?: number | null;
   onMentionClick?: (uid: number) => void;
 }
@@ -88,6 +93,7 @@ export function MessageOverlay(props: MessageOverlayProps) {
     reactions,
     onClose,
     mentions,
+    forwardedFrom,
     currentUserUid,
     onMentionClick,
   } = props;
@@ -412,6 +418,7 @@ export function MessageOverlay(props: MessageOverlayProps) {
         replyTo={replyTo}
         edited={edited}
         isConfirmed={isConfirmed}
+        forwardedFrom={forwardedFrom}
       />
     );
   } else {
@@ -425,6 +432,7 @@ export function MessageOverlay(props: MessageOverlayProps) {
         isConfirmed={isConfirmed}
         attachments={props.attachments}
         mentions={mentions}
+        forwardedFrom={forwardedFrom}
         currentUserUid={currentUserUid}
         onMentionClick={onMentionClick}
       />

--- a/wetty-chat-mobile/src/components/chat/messages/ReplyPreview.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/ReplyPreview.tsx
@@ -1,10 +1,8 @@
 import { useSelector } from 'react-redux';
-import { IonIcon } from '@ionic/react';
-import { arrowRedoOutline } from 'ionicons/icons';
-import { t } from '@lingui/core/macro';
 import { formatMessagePreview, type PreviewMessage, getNotificationPreviewLabels } from '@/utils/messagePreview';
 import { selectEffectiveLocale } from '@/store/settingsSlice';
 import { colorForUser } from '@/utils/userColor';
+import { ForwardedLabel } from './ForwardedLabel';
 import styles from './ChatBubble.module.scss';
 
 export interface ReplyPreviewInfo {
@@ -38,10 +36,7 @@ export function ReplyPreview({ replyTo, isSent, interactive, onReplyTap }: Reply
       }
     >
       {replyTo.forwardedFromName ? (
-        <div className={styles.forwardedLabel}>
-          <IonIcon icon={arrowRedoOutline} className={styles.forwardedIcon} />
-          {t`Forwarded from ${replyTo.forwardedFromName}`}
-        </div>
+        <ForwardedLabel name={replyTo.forwardedFromName} />
       ) : (
         <div className={styles.replyPreviewName} style={color ? { color } : undefined}>
           {replyTo.senderName}

--- a/wetty-chat-mobile/src/components/chat/messages/ReplyPreview.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/ReplyPreview.tsx
@@ -1,4 +1,7 @@
 import { useSelector } from 'react-redux';
+import { IonIcon } from '@ionic/react';
+import { arrowRedoOutline } from 'ionicons/icons';
+import { t } from '@lingui/core/macro';
 import { formatMessagePreview, type PreviewMessage, getNotificationPreviewLabels } from '@/utils/messagePreview';
 import { selectEffectiveLocale } from '@/store/settingsSlice';
 import { colorForUser } from '@/utils/userColor';
@@ -7,6 +10,7 @@ import styles from './ChatBubble.module.scss';
 export interface ReplyPreviewInfo {
   senderName: string;
   preview: PreviewMessage;
+  forwardedFromName?: string | null;
 }
 
 interface ReplyPreviewProps {
@@ -33,9 +37,16 @@ export function ReplyPreview({ replyTo, isSent, interactive, onReplyTap }: Reply
           : undefined
       }
     >
-      <div className={styles.replyPreviewName} style={color ? { color } : undefined}>
-        {replyTo.senderName}
-      </div>
+      {replyTo.forwardedFromName ? (
+        <div className={styles.forwardedLabel}>
+          <IonIcon icon={arrowRedoOutline} className={styles.forwardedIcon} />
+          {t`Forwarded from ${replyTo.forwardedFromName}`}
+        </div>
+      ) : (
+        <div className={styles.replyPreviewName} style={color ? { color } : undefined}>
+          {replyTo.senderName}
+        </div>
+      )}
       <div className={styles.replyPreviewText}>
         {formatMessagePreview(replyTo.preview, getNotificationPreviewLabels(locale))}
       </div>

--- a/wetty-chat-mobile/src/components/chat/messages/StickerBubble.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/StickerBubble.tsx
@@ -1,6 +1,6 @@
 import { useState, type Ref } from 'react';
 import { IonIcon } from '@ionic/react';
-import { arrowRedoOutline, chatbubbles, checkmarkCircle, checkmarkCircleOutline } from 'ionicons/icons';
+import { chatbubbles, checkmarkCircle, checkmarkCircleOutline } from 'ionicons/icons';
 import { t } from '@lingui/core/macro';
 import { StickerImage } from '@/components/shared/StickerImage';
 import styles from './ChatBubble.module.scss';
@@ -11,6 +11,7 @@ import { useMouseDetected } from '@/hooks/platformHooks';
 import type { BubblePropsOverride } from './ChatBubbleBase';
 import { formatTime } from '@/utils/formatTime';
 import { ReplyPreview } from './ReplyPreview';
+import { ForwardedLabel } from './ForwardedLabel';
 
 export interface StickerBubbleProps {
   messageType?: 'sticker';
@@ -78,12 +79,7 @@ export function StickerBubble({
         .join(' ')}
       style={bubbleStyle}
     >
-      {forwardedFrom && (
-        <div className={styles.forwardedLabel}>
-          <IonIcon icon={arrowRedoOutline} className={styles.forwardedIcon} />
-          <span>{t`Forwarded from ${forwardedFrom.sender.name ?? t`Unknown`}`}</span>
-        </div>
-      )}
+      {forwardedFrom && <ForwardedLabel name={forwardedFrom.sender.name} />}
       {replyTo && <ReplyPreview replyTo={replyTo} isSent={isSent} interactive={interactive} onReplyTap={onReplyTap} />}
       <div className={styles.stickerContainer}>
         <StickerImage

--- a/wetty-chat-mobile/src/components/chat/messages/StickerBubble.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/StickerBubble.tsx
@@ -79,6 +79,10 @@ export function StickerBubble({
         .join(' ')}
       style={bubbleStyle}
     >
+      {/* Intentional: forwarded stickers always render exactly like a normally
+          sent sticker — we deliberately do NOT show the inner forwarded reply
+          preview (forwardedFrom.originalReplyTo) here, unlike ChatBubbleBase.
+          A forwarded sticker should look identical to one you sent yourself. */}
       {forwardedFrom && <ForwardedLabel name={forwardedFrom.sender.name} />}
       {replyTo && <ReplyPreview replyTo={replyTo} isSent={isSent} interactive={interactive} onReplyTap={onReplyTap} />}
       <div className={styles.stickerContainer}>

--- a/wetty-chat-mobile/src/components/chat/messages/StickerBubble.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/StickerBubble.tsx
@@ -1,6 +1,6 @@
 import { useState, type Ref } from 'react';
 import { IonIcon } from '@ionic/react';
-import { chatbubbles, checkmarkCircle, checkmarkCircleOutline } from 'ionicons/icons';
+import { arrowRedoOutline, chatbubbles, checkmarkCircle, checkmarkCircleOutline } from 'ionicons/icons';
 import { t } from '@lingui/core/macro';
 import { StickerImage } from '@/components/shared/StickerImage';
 import styles from './ChatBubble.module.scss';
@@ -26,7 +26,11 @@ export interface StickerBubbleProps {
   replyTo?: {
     senderName: string;
     preview: PreviewMessage;
+    forwardedFromName?: string | null;
   };
+  forwardedFrom?: {
+    sender: { name: string | null };
+  } | null;
   timestamp?: string;
   edited?: boolean;
   isConfirmed?: boolean;
@@ -49,6 +53,7 @@ export function StickerBubble({
   onReplyTap,
   onAvatarClick,
   replyTo,
+  forwardedFrom,
   timestamp,
   edited,
   isConfirmed,
@@ -73,7 +78,13 @@ export function StickerBubble({
         .join(' ')}
       style={bubbleStyle}
     >
-      {replyTo && <ReplyPreview replyTo={replyTo} interactive={interactive} onReplyTap={onReplyTap} />}
+      {forwardedFrom && (
+        <div className={styles.forwardedLabel}>
+          <IonIcon icon={arrowRedoOutline} className={styles.forwardedIcon} />
+          <span>{t`Forwarded from ${forwardedFrom.sender.name ?? t`Unknown`}`}</span>
+        </div>
+      )}
+      {replyTo && <ReplyPreview replyTo={replyTo} isSent={isSent} interactive={interactive} onReplyTap={onReplyTap} />}
       <div className={styles.stickerContainer}>
         <StickerImage
           src={stickerUrl}

--- a/wetty-chat-mobile/src/components/chat/messages/useForwardTargetList.ts
+++ b/wetty-chat-mobile/src/components/chat/messages/useForwardTargetList.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+import { getChats, type ChatListEntry } from '@/api/chats';
+import { getThreads, type ThreadListItem } from '@/api/threads';
+import { t } from '@lingui/core/macro';
+
+const FORWARD_THREAD_LIMIT = 50;
+
+export function useForwardTargetList(isOpen: boolean) {
+  const [chats, setChats] = useState<ChatListEntry[]>([]);
+  const [threads, setThreads] = useState<ThreadListItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    let cancelled = false;
+
+    Promise.all([getChats({ archived: false }), getThreads({ limit: FORWARD_THREAD_LIMIT, archived: false })])
+      .then(([chatRes, threadRes]) => {
+        if (!cancelled) {
+          setChats(chatRes.data.chats);
+          setThreads(threadRes.data.threads);
+          setLoading(false);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : t`Failed to load chats`);
+          setLoading(false);
+        }
+      });
+
+    // Delayed loading indicator to avoid synchronous setState in effect body.
+    queueMicrotask(() => {
+      if (!cancelled) {
+        setLoading(true);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen]);
+
+  // When closed, return empty state without triggering re-renders.
+  // Stale data from previous opens is overwritten by the next fetch callback.
+  return isOpen ? { chats, threads, loading, error } : { chats: [], threads: [], loading: false, error: null };
+}

--- a/wetty-chat-mobile/src/features.ts
+++ b/wetty-chat-mobile/src/features.ts
@@ -35,6 +35,10 @@ export const FEATURES = {
     enabled: false,
     description: 'Stores landing auth/invite state for PWA handoff and shows pending invites inside the installed app.',
   },
+  messageForward: {
+    enabled: true,
+    description: 'Allows users to forward messages to other chats.',
+  },
 } as const;
 
 export type Feature = keyof typeof FEATURES;

--- a/wetty-chat-mobile/src/pages/conversation/ConversationOverlayHost.tsx
+++ b/wetty-chat-mobile/src/pages/conversation/ConversationOverlayHost.tsx
@@ -89,6 +89,7 @@ export function ConversationOverlayHost({
                 ? {
                     senderName: msg.replyToMessage.sender.name ?? `User ${msg.replyToMessage.sender.uid}`,
                     preview: msg.replyToMessage,
+                    forwardedFromName: msg.replyToMessage.forwardedFromName,
                   }
                 : undefined,
               sourceRect: overlayMessage.sourceRect,
@@ -105,6 +106,7 @@ export function ConversationOverlayHost({
                   },
               onClose: onCloseOverlay,
               mentions: msg.mentions ?? undefined,
+              forwardedFrom: msg.forwardedFrom ?? undefined,
               currentUserUid: currentUserId,
               onMentionClick: (uid: number) => onProfileSenderChange(mentionToUser(msg.mentions, uid)),
             } as const;

--- a/wetty-chat-mobile/src/pages/conversation/conversation.tsx
+++ b/wetty-chat-mobile/src/pages/conversation/conversation.tsx
@@ -21,6 +21,7 @@ import { useFeatureGate } from '@/hooks/useFeatureGate';
 import { ConversationFooter } from './ConversationFooter';
 import { ConversationHeader } from './ConversationHeader';
 import { ConversationOverlayHost } from './ConversationOverlayHost';
+import { ForwardMessageModal } from '@/components/chat/messages/ForwardMessageModal';
 import { useChatMetadata } from './hooks/useChatMetadata';
 import { useChatPins } from './hooks/useChatPins';
 import { type ChatMessageEditSession, useChatMessageSender } from './hooks/useChatMessageSender';
@@ -49,6 +50,7 @@ function ConversationPane({ chatId, threadId, backAction }: ConversationPaneProp
 
   // Feature Gates
   const savedMessagesEnabled = useFeatureGate('savedMessages');
+  const messageForwardEnabled = useFeatureGate('messageForward');
 
   // Global states
   const locale = useSelector(selectEffectiveLocale);
@@ -160,6 +162,7 @@ function ConversationPane({ chatId, threadId, backAction }: ConversationPaneProp
     sourceRect: DOMRect;
     interactionPos?: { x: number; y: number };
   } | null>(null);
+  const [forwardingMessage, setForwardingMessage] = useState<MessageResponse | null>(null);
 
   // When a long-press happens while the keyboard is open we defer showing the
   // overlay until the keyboard has fully closed, while preserving the press-time
@@ -365,6 +368,7 @@ function ConversationPane({ chatId, threadId, backAction }: ConversationPaneProp
     onReply: setReplyingTo,
     onStartThread: handleSelectThread,
     onEdit: startEditingMessage,
+    onForward: setForwardingMessage,
     onOpenReactionDetails: handleOpenReactionDetails,
   });
 
@@ -518,6 +522,7 @@ function ConversationPane({ chatId, threadId, backAction }: ConversationPaneProp
                   attachments: replyingTo.attachments,
                   isDeleted: replyingTo.isDeleted,
                   mentions: replyingTo.mentions,
+                  forwardedFromName: replyingTo.forwardedFrom?.sender.name,
                 }
               : undefined
           }
@@ -547,6 +552,14 @@ function ConversationPane({ chatId, threadId, backAction }: ConversationPaneProp
           onReactionToggle={handleReactionToggle}
           onCloseOverlay={handleCloseOverlay}
         />
+        {forwardingMessage && chatId && messageForwardEnabled && (
+          <ForwardMessageModal
+            isOpen={true}
+            onClose={() => setForwardingMessage(null)}
+            message={forwardingMessage}
+            sourceChatId={chatId}
+          />
+        )}
       </div>
     </ChatContext.Provider>
   );

--- a/wetty-chat-mobile/src/pages/conversation/hooks/useChatMessageSender.dom.test.tsx
+++ b/wetty-chat-mobile/src/pages/conversation/hooks/useChatMessageSender.dom.test.tsx
@@ -3,7 +3,7 @@ import { createRoot, type Root } from 'react-dom/client';
 import type { AxiosResponse } from 'axios';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MessageResponse } from '@/api/messages';
-import { markMessagesAsRead, sendMessage } from '@/api/messages';
+import { markMessagesAsRead, sendMessage, sendThreadMessage } from '@/api/messages';
 import { useChatMessageSender } from './useChatMessageSender';
 
 function response<T>(data: T): AxiosResponse<T> {
@@ -181,5 +181,129 @@ describe('useChatMessageSender', () => {
         }),
       }),
     );
+  });
+
+  it('dispatches optimistic and confirmed actions for a thread text send', async () => {
+    vi.mocked(sendThreadMessage).mockResolvedValue(response(message({ id: 'server-1', replyRootId: 'thread-1' })));
+
+    // Create a test component with threadId
+    function ThreadTestComponent({ onRender }: { onRender: (state: HookState) => void }) {
+      const sender = useChatMessageSender({
+        chatId: 'chat-1',
+        storeChatId: 'chat-1_thread_thread-1',
+        threadId: 'thread-1',
+        currentUserId: 7,
+        currentUserName: 'Me',
+        currentUserAvatarUrl: null,
+        threadSubscribed: true,
+        replyingTo: null,
+        editingSession: null,
+        messageLookup: new Map(),
+        setReplyingTo,
+        setEditingSession,
+        revealLatestAfterSend,
+        markThreadSubscribedOptimistically,
+        showToast,
+      });
+      onRender({ sender });
+      return null;
+    }
+
+    await act(async () => {
+      root.render(
+        <ThreadTestComponent
+          onRender={(nextState) => {
+            state = nextState;
+          }}
+        />,
+      );
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      state.sender.handleSend({
+        kind: 'text',
+        text: 'thread reply',
+        attachmentIds: [],
+        existingAttachments: [],
+        uploadedAttachments: [],
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Should use sendThreadMessage, not sendMessage
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(sendThreadMessage).toHaveBeenCalledWith(
+      'chat-1',
+      'thread-1',
+      expect.objectContaining({
+        message: 'thread reply',
+        messageType: 'text',
+      }),
+    );
+
+    // Should dispatch with scope: 'thread'
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'messages/messageAdded',
+        payload: expect.objectContaining({
+          scope: 'thread',
+        }),
+      }),
+    );
+  });
+
+  it('auto-subscribes to thread when sending in an unsubscribed thread', async () => {
+    vi.mocked(sendThreadMessage).mockResolvedValue(response(message({ id: 'server-1', replyRootId: 'thread-1' })));
+
+    function UnsubscribedThreadTestComponent({ onRender }: { onRender: (state: HookState) => void }) {
+      const sender = useChatMessageSender({
+        chatId: 'chat-1',
+        storeChatId: 'chat-1_thread_thread-1',
+        threadId: 'thread-1',
+        currentUserId: 7,
+        currentUserName: 'Me',
+        currentUserAvatarUrl: null,
+        threadSubscribed: false, // Not subscribed
+        replyingTo: null,
+        editingSession: null,
+        messageLookup: new Map(),
+        setReplyingTo,
+        setEditingSession,
+        revealLatestAfterSend,
+        markThreadSubscribedOptimistically,
+        showToast,
+      });
+      onRender({ sender });
+      return null;
+    }
+
+    await act(async () => {
+      root.render(
+        <UnsubscribedThreadTestComponent
+          onRender={(nextState) => {
+            state = nextState;
+          }}
+        />,
+      );
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      state.sender.handleSend({
+        kind: 'text',
+        text: 'auto subscribe',
+        attachmentIds: [],
+        existingAttachments: [],
+        uploadedAttachments: [],
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Should call markThreadSubscribedOptimistically before sending
+    expect(markThreadSubscribedOptimistically).toHaveBeenCalled();
+    expect(sendThreadMessage).toHaveBeenCalled();
   });
 });

--- a/wetty-chat-mobile/src/pages/conversation/hooks/useChatMessageSender.ts
+++ b/wetty-chat-mobile/src/pages/conversation/hooks/useChatMessageSender.ts
@@ -59,6 +59,7 @@ function buildReplyPreview(replyingTo: MessageResponse | null): MessageResponse[
         isDeleted: replyingTo.isDeleted,
         attachments: replyingTo.attachments,
         mentions: replyingTo.mentions,
+        forwardedFromName: replyingTo.forwardedFrom?.sender.name,
       }
     : undefined;
 }

--- a/wetty-chat-mobile/src/pages/conversation/hooks/useMessageOverlayActions.dom.test.tsx
+++ b/wetty-chat-mobile/src/pages/conversation/hooks/useMessageOverlayActions.dom.test.tsx
@@ -88,6 +88,7 @@ function TestComponent({
   onStartThread,
   onEdit,
   onOpenReactionDetails,
+  onForward,
 }: {
   message: MessageResponse | null;
   pins: PinResponse[];
@@ -98,6 +99,7 @@ function TestComponent({
   onStartThread: (messageId: string) => void;
   onEdit: (message: MessageResponse) => void;
   onOpenReactionDetails: (messageId: string) => void;
+  onForward: (message: MessageResponse) => void;
 }) {
   const actions = useMessageOverlayActions({
     chatId: 'chat-1',
@@ -113,6 +115,7 @@ function TestComponent({
     onStartThread,
     onEdit,
     onOpenReactionDetails,
+    onForward,
   });
   onRender({ actions });
   return null;
@@ -128,6 +131,7 @@ describe('useMessageOverlayActions', () => {
   let onStartThread: MockFn<(messageId: string) => void>;
   let onEdit: MockFn<(message: MessageResponse) => void>;
   let onOpenReactionDetails: MockFn<(messageId: string) => void>;
+  let onForward: MockFn<(message: MessageResponse) => void>;
 
   function renderHook(nextMessage: MessageResponse | null, pins: PinResponse[] = []) {
     act(() => {
@@ -141,6 +145,7 @@ describe('useMessageOverlayActions', () => {
           onStartThread={onStartThread}
           onEdit={onEdit}
           onOpenReactionDetails={onOpenReactionDetails}
+          onForward={onForward}
           onRender={(nextState) => (state = nextState)}
         />,
       );
@@ -158,6 +163,7 @@ describe('useMessageOverlayActions', () => {
     onStartThread = vi.fn() as typeof onStartThread;
     onEdit = vi.fn() as typeof onEdit;
     onOpenReactionDetails = vi.fn() as typeof onOpenReactionDetails;
+    onForward = vi.fn() as typeof onForward;
     vi.mocked(createPin).mockResolvedValue(response(pinFor(message())));
     vi.mocked(deletePin).mockResolvedValue(response(undefined));
     vi.mocked(deleteMessage).mockResolvedValue(response(undefined));
@@ -187,6 +193,7 @@ describe('useMessageOverlayActions', () => {
       'thread',
       'pin',
       'copy',
+      'forward',
       'edit',
       'save',
       'copy-link',

--- a/wetty-chat-mobile/src/pages/conversation/hooks/useMessageOverlayActions.dom.test.tsx
+++ b/wetty-chat-mobile/src/pages/conversation/hooks/useMessageOverlayActions.dom.test.tsx
@@ -87,8 +87,8 @@ function TestComponent({
   onReply,
   onStartThread,
   onEdit,
-  onOpenReactionDetails,
   onForward,
+  onOpenReactionDetails,
 }: {
   message: MessageResponse | null;
   pins: PinResponse[];
@@ -98,8 +98,8 @@ function TestComponent({
   onReply: (message: MessageResponse) => void;
   onStartThread: (messageId: string) => void;
   onEdit: (message: MessageResponse) => void;
-  onOpenReactionDetails: (messageId: string) => void;
   onForward: (message: MessageResponse) => void;
+  onOpenReactionDetails: (messageId: string) => void;
 }) {
   const actions = useMessageOverlayActions({
     chatId: 'chat-1',
@@ -114,8 +114,8 @@ function TestComponent({
     onReply,
     onStartThread,
     onEdit,
-    onOpenReactionDetails,
     onForward,
+    onOpenReactionDetails,
   });
   onRender({ actions });
   return null;
@@ -130,8 +130,8 @@ describe('useMessageOverlayActions', () => {
   let onReply: MockFn<(message: MessageResponse) => void>;
   let onStartThread: MockFn<(messageId: string) => void>;
   let onEdit: MockFn<(message: MessageResponse) => void>;
-  let onOpenReactionDetails: MockFn<(messageId: string) => void>;
   let onForward: MockFn<(message: MessageResponse) => void>;
+  let onOpenReactionDetails: MockFn<(messageId: string) => void>;
 
   function renderHook(nextMessage: MessageResponse | null, pins: PinResponse[] = []) {
     act(() => {
@@ -144,8 +144,8 @@ describe('useMessageOverlayActions', () => {
           onReply={onReply}
           onStartThread={onStartThread}
           onEdit={onEdit}
-          onOpenReactionDetails={onOpenReactionDetails}
           onForward={onForward}
+          onOpenReactionDetails={onOpenReactionDetails}
           onRender={(nextState) => (state = nextState)}
         />,
       );
@@ -162,8 +162,8 @@ describe('useMessageOverlayActions', () => {
     onReply = vi.fn() as typeof onReply;
     onStartThread = vi.fn() as typeof onStartThread;
     onEdit = vi.fn() as typeof onEdit;
-    onOpenReactionDetails = vi.fn() as typeof onOpenReactionDetails;
     onForward = vi.fn() as typeof onForward;
+    onOpenReactionDetails = vi.fn() as typeof onOpenReactionDetails;
     vi.mocked(createPin).mockResolvedValue(response(pinFor(message())));
     vi.mocked(deletePin).mockResolvedValue(response(undefined));
     vi.mocked(deleteMessage).mockResolvedValue(response(undefined));
@@ -208,12 +208,14 @@ describe('useMessageOverlayActions', () => {
     state.actions.find((action) => action.key === 'reply')?.handler();
     state.actions.find((action) => action.key === 'thread')?.handler();
     state.actions.find((action) => action.key === 'edit')?.handler();
+    state.actions.find((action) => action.key === 'forward')?.handler();
     state.actions.find((action) => action.key === 'reaction-details')?.handler();
 
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith('hello');
     expect(onReply).toHaveBeenCalledWith(expect.objectContaining({ id: 'message-1' }));
     expect(onStartThread).toHaveBeenCalledWith('message-1');
     expect(onEdit).toHaveBeenCalledWith(expect.objectContaining({ id: 'message-1' }));
+    expect(onForward).toHaveBeenCalledWith(expect.objectContaining({ id: 'message-1' }));
     expect(onOpenReactionDetails).toHaveBeenCalledWith('message-1');
   });
 

--- a/wetty-chat-mobile/src/pages/conversation/hooks/useMessageOverlayActions.ts
+++ b/wetty-chat-mobile/src/pages/conversation/hooks/useMessageOverlayActions.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { t } from '@lingui/core/macro';
 import {
   arrowUndoOutline,
+  arrowRedoOutline,
   bookmarkOutline,
   chatbubblesOutline,
   copyOutline,
@@ -48,6 +49,7 @@ interface UseMessageOverlayActionsArgs {
   onReply: (message: MessageResponse) => void;
   onStartThread: (messageId: string) => void;
   onEdit: (message: MessageResponse) => void;
+  onForward: (message: MessageResponse) => void;
   onOpenReactionDetails: (messageId: string) => void;
 }
 
@@ -64,6 +66,7 @@ export function useMessageOverlayActions({
   onReply,
   onStartThread,
   onEdit,
+  onForward,
   onOpenReactionDetails,
 }: UseMessageOverlayActionsArgs): MessageOverlayAction[] {
   const dispatch = useDispatch();
@@ -86,6 +89,7 @@ export function useMessageOverlayActions({
       savedMessagesEnabled,
       isPinned: existingPin != null,
       hasReactions: (message.reactions?.length ?? 0) > 0,
+      isForwarded: !!message.forwardedFrom,
     });
     const actions: MessageOverlayAction[] = [];
 
@@ -168,6 +172,16 @@ export function useMessageOverlayActions({
             icon: arrowUndoOutline,
             handler: () => {
               onReply(message);
+            },
+          });
+          break;
+        case 'forward':
+          actions.push({
+            key: 'forward',
+            label: t`Forward`,
+            icon: arrowRedoOutline,
+            handler: () => {
+              onForward(message);
             },
           });
           break;
@@ -272,6 +286,7 @@ export function useMessageOverlayActions({
     isAdmin,
     message,
     onEdit,
+    onForward,
     onOpenReactionDetails,
     onReply,
     onStartThread,

--- a/wetty-chat-mobile/src/pages/conversation/utils/overlayActionPolicy.test.ts
+++ b/wetty-chat-mobile/src/pages/conversation/utils/overlayActionPolicy.test.ts
@@ -14,6 +14,7 @@ const baseInput: OverlayActionPolicyInput = {
   savedMessagesEnabled: true,
   isPinned: false,
   hasReactions: false,
+  isForwarded: false,
 };
 
 function keys(input: Partial<OverlayActionPolicyInput> = {}) {
@@ -22,7 +23,7 @@ function keys(input: Partial<OverlayActionPolicyInput> = {}) {
 
 describe('overlay action policy', () => {
   it('preserves default text message action order', () => {
-    expect(keys()).toEqual(['reply', 'thread', 'copy', 'save', 'copy-link']);
+    expect(keys()).toEqual(['reply', 'thread', 'copy', 'forward', 'save', 'copy-link']);
   });
 
   it('uses copy text variant when a text message also has attachments', () => {
@@ -33,7 +34,7 @@ describe('overlay action policy', () => {
   });
 
   it('omits copy when a regular message has no text', () => {
-    expect(keys({ text: '', hasAttachments: true })).toEqual(['reply', 'thread', 'save', 'copy-link']);
+    expect(keys({ text: '', hasAttachments: true })).toEqual(['reply', 'thread', 'forward', 'save', 'copy-link']);
   });
 
   it('adds edit and delete for own regular messages, but not when deleted', () => {
@@ -41,6 +42,7 @@ describe('overlay action policy', () => {
       'reply',
       'thread',
       'copy',
+      'forward',
       'edit',
       'copy-link',
       'delete',
@@ -49,7 +51,16 @@ describe('overlay action policy', () => {
   });
 
   it('adds delete and pin state for admins in main chat', () => {
-    expect(keys({ isAdmin: true })).toEqual(['reply', 'thread', 'pin', 'copy', 'save', 'copy-link', 'delete']);
+    expect(keys({ isAdmin: true })).toEqual([
+      'reply',
+      'thread',
+      'pin',
+      'copy',
+      'forward',
+      'save',
+      'copy-link',
+      'delete',
+    ]);
     expect(getOverlayActionPolicy({ ...baseInput, isAdmin: true, isPinned: true }).at(2)).toEqual({
       key: 'pin',
       pinState: 'pinned',
@@ -57,16 +68,29 @@ describe('overlay action policy', () => {
   });
 
   it('does not offer thread or pin actions inside thread view', () => {
-    expect(keys({ isThreadView: true, isAdmin: true })).toEqual(['reply', 'copy', 'save', 'copy-link', 'delete']);
+    expect(keys({ isThreadView: true, isAdmin: true })).toEqual([
+      'reply',
+      'copy',
+      'forward',
+      'save',
+      'copy-link',
+      'delete',
+    ]);
   });
 
   it('does not offer start thread when the message already has thread info', () => {
-    expect(keys({ hasThreadInfo: true })).toEqual(['reply', 'copy', 'save', 'copy-link']);
+    expect(keys({ hasThreadInfo: true })).toEqual(['reply', 'copy', 'forward', 'save', 'copy-link']);
   });
 
   it('preserves current optimistic and deleted save/pin restrictions', () => {
-    expect(keys({ isOptimistic: true })).toEqual(['reply', 'thread', 'copy', 'copy-link']);
+    expect(keys({ isOptimistic: true })).toEqual(['reply', 'thread', 'copy', 'forward', 'copy-link']);
     expect(keys({ isDeleted: true, text: null, isAdmin: true })).toEqual(['reply', 'copy-link']);
+  });
+
+  it('does not offer forward for deleted messages', () => {
+    expect(keys({ isDeleted: true, text: 'hello' })).not.toContain('forward');
+    expect(keys({ isDeleted: true, text: null })).not.toContain('forward');
+    expect(keys({ isDeleted: true, isAdmin: true })).not.toContain('forward');
   });
 
   it('keeps sticker actions filtered to reply delete copy link and favorite', () => {
@@ -76,7 +100,7 @@ describe('overlay action policy', () => {
         isAdmin: true,
         hasReactions: true,
       }),
-    ).toEqual(['reply', 'favorite', 'copy-link', 'delete']);
+    ).toEqual(['reply', 'forward', 'favorite', 'copy-link', 'delete']);
   });
 
   it('uses audio action rules without copy or edit', () => {
@@ -84,6 +108,7 @@ describe('overlay action policy', () => {
       'reply',
       'thread',
       'pin',
+      'forward',
       'save',
       'copy-link',
       'delete',
@@ -91,11 +116,19 @@ describe('overlay action policy', () => {
   });
 
   it('adds reaction details only when reactions are present for non-sticker messages', () => {
-    expect(keys({ hasReactions: true })).toEqual(['reply', 'thread', 'copy', 'save', 'copy-link', 'reaction-details']);
+    expect(keys({ hasReactions: true })).toEqual([
+      'reply',
+      'thread',
+      'copy',
+      'forward',
+      'save',
+      'copy-link',
+      'reaction-details',
+    ]);
   });
 
   it('disables save when the feature is off or the message is system', () => {
-    expect(keys({ savedMessagesEnabled: false })).toEqual(['reply', 'thread', 'copy', 'copy-link']);
-    expect(keys({ messageType: 'system' })).toEqual(['reply', 'thread', 'copy', 'copy-link']);
+    expect(keys({ savedMessagesEnabled: false })).toEqual(['reply', 'thread', 'copy', 'forward', 'copy-link']);
+    expect(keys({ messageType: 'system' })).toEqual(['reply', 'thread', 'copy', 'forward', 'copy-link']);
   });
 });

--- a/wetty-chat-mobile/src/pages/conversation/utils/overlayActionPolicy.ts
+++ b/wetty-chat-mobile/src/pages/conversation/utils/overlayActionPolicy.ts
@@ -1,4 +1,6 @@
 import type { MessageType } from '@/api/messages';
+import { isFeatureEnabled } from '@/features';
+
 export type OverlayActionKey =
   | 'copy'
   | 'copy-link'
@@ -58,7 +60,9 @@ export function getOverlayActionPolicy(input: OverlayActionPolicyInput): Overlay
   }
 
   // 5. Forward
-  actions.push({ key: 'forward' });
+  if (isFeatureEnabled('messageForward') && !input.isDeleted) {
+    actions.push({ key: 'forward' });
+  }
 
   // 6. Edit
   if (input.isOwn && !input.isDeleted && !input.isForwarded && !audioMessage && !stickerMessage) {

--- a/wetty-chat-mobile/src/pages/conversation/utils/overlayActionPolicy.ts
+++ b/wetty-chat-mobile/src/pages/conversation/utils/overlayActionPolicy.ts
@@ -1,11 +1,11 @@
 import type { MessageType } from '@/api/messages';
-
 export type OverlayActionKey =
   | 'copy'
   | 'copy-link'
   | 'favorite'
   | 'save'
   | 'reply'
+  | 'forward'
   | 'thread'
   | 'edit'
   | 'delete'
@@ -25,6 +25,7 @@ export interface OverlayActionPolicyInput {
   savedMessagesEnabled: boolean;
   isPinned: boolean;
   hasReactions: boolean;
+  isForwarded: boolean;
 }
 
 export type OverlayActionPolicyItem =
@@ -56,27 +57,30 @@ export function getOverlayActionPolicy(input: OverlayActionPolicyInput): Overlay
     actions.push({ key: 'copy', copyVariant: input.hasAttachments ? 'text' : 'message' });
   }
 
-  // 5. Edit
-  if (input.isOwn && !input.isDeleted && !audioMessage && !stickerMessage) {
+  // 5. Forward
+  actions.push({ key: 'forward' });
+
+  // 6. Edit
+  if (input.isOwn && !input.isDeleted && !input.isForwarded && !audioMessage && !stickerMessage) {
     actions.push({ key: 'edit' });
   }
 
-  // 6. Save / Favorite
+  // 7. Save / Favorite
   if (stickerMessage && isDeletableAction) {
     actions.push({ key: 'favorite' });
   } else if (input.savedMessagesEnabled && isDeletableAction && input.messageType !== 'system') {
     actions.push({ key: 'save' });
   }
 
-  // 7. Copy-link
+  // 8. Copy-link
   actions.push({ key: 'copy-link' });
 
-  // 8. Delete
+  // 9. Delete
   if ((input.isOwn || input.isAdmin) && !input.isDeleted) {
     actions.push({ key: 'delete' });
   }
 
-  // 9. Details
+  // 10. Details
   if (input.hasReactions) {
     actions.push({ key: 'reaction-details' });
   }
@@ -84,7 +88,11 @@ export function getOverlayActionPolicy(input: OverlayActionPolicyInput): Overlay
   if (stickerMessage) {
     return actions.filter(
       (action) =>
-        action.key === 'reply' || action.key === 'delete' || action.key === 'copy-link' || action.key === 'favorite',
+        action.key === 'reply' ||
+        action.key === 'forward' ||
+        action.key === 'delete' ||
+        action.key === 'copy-link' ||
+        action.key === 'favorite',
     );
   }
 

--- a/wetty-chat-mobile/src/store/messages/slice.test.ts
+++ b/wetty-chat-mobile/src/store/messages/slice.test.ts
@@ -356,4 +356,249 @@ describe('messages slice canonical reducers', () => {
     expect(selectActiveTimelineMessages(testRootState(next), '1')[0].reactions?.[0]?.emoji).toBe('thumbs-up');
     expect(selectActiveTimelineMessages(testRootState(next), '1_thread_10')[0].replyToMessage?.isDeleted).toBe(true);
   });
+
+  it('updates replyToMessage.isDeleted when the referenced message is deleted via messagePatched', () => {
+    const replyToMessage: MessageResponse['replyToMessage'] = {
+      id: '10',
+      clientGeneratedId: 'client-10',
+      createdAt: testMessage('10').createdAt,
+      message: 'message 10',
+      messageType: 'text',
+      sender: { uid: 2, name: 'User', gender: 0 },
+      isDeleted: false,
+    };
+    let next = reducer(
+      undefined,
+      refreshLatest({
+        chatId: '1',
+        messages: [testMessage('10'), testMessage('11', 'client-11', { replyToMessage })],
+        olderCursor: null,
+        newerCursor: null,
+      }),
+    );
+
+    // Delete msg10 via messagePatched (single delete path)
+    next = reducer(
+      next,
+      messagePatched({
+        chatId: '1',
+        messageId: '10',
+        message: testMessage('10', 'client-10', { isDeleted: true, message: null }),
+      }),
+    );
+
+    // msg10 removed from timeline
+    expect(ids(selectActiveTimelineMessages(testRootState(next), '1'))).toEqual(['11']);
+    // msg11's replyToMessage.isDeleted updated to true
+    expect(selectActiveTimelineMessages(testRootState(next), '1')[0].replyToMessage?.isDeleted).toBe(true);
+    expect(selectActiveTimelineMessages(testRootState(next), '1')[0].replyToMessage?.message).toBeNull();
+  });
+
+  it('keeps thread root as placeholder when deleted but threadInfo exists', () => {
+    let next = reducer(
+      undefined,
+      refreshLatest({
+        chatId: '1',
+        messages: [testMessage('10', 'client-10', { threadInfo: { replyCount: 3 } }), testMessage('11')],
+        olderCursor: null,
+        newerCursor: null,
+      }),
+    );
+
+    // Delete thread root via messagePatched
+    next = reducer(
+      next,
+      messagePatched({
+        chatId: '1',
+        messageId: '10',
+        message: testMessage('10', 'client-10', { isDeleted: true, message: null, threadInfo: { replyCount: 3 } }),
+      }),
+    );
+
+    // Thread root stays as placeholder (has threadInfo)
+    const messages = selectActiveTimelineMessages(testRootState(next), '1');
+    expect(ids(messages)).toEqual(['10', '11']);
+    expect(messages[0].isDeleted).toBe(true);
+    expect(messages[0].message).toBeNull();
+    expect(messages[0].threadInfo).toEqual({ replyCount: 3 });
+  });
+
+  it('removes thread root when deleted and threadInfo is null', () => {
+    let next = reducer(
+      undefined,
+      refreshLatest({
+        chatId: '1',
+        messages: [testMessage('10', 'client-10', { threadInfo: { replyCount: 3 } }), testMessage('11')],
+        olderCursor: null,
+        newerCursor: null,
+      }),
+    );
+
+    // Delete thread root with threadInfo explicitly set to null (server says no thread)
+    next = reducer(
+      next,
+      messagePatched({
+        chatId: '1',
+        messageId: '10',
+        message: testMessage('10', 'client-10', { isDeleted: true, message: null, threadInfo: null as any }),
+      }),
+    );
+
+    // Thread root removed (threadInfo is null/falsy)
+    expect(ids(selectActiveTimelineMessages(testRootState(next), '1'))).toEqual(['11']);
+  });
+
+  it('removes thread root when deleted and no threadInfo on existing message', () => {
+    let next = reducer(
+      undefined,
+      refreshLatest({
+        chatId: '1',
+        messages: [testMessage('10'), testMessage('11')],
+        olderCursor: null,
+        newerCursor: null,
+      }),
+    );
+
+    // Delete a regular message (no threadInfo)
+    next = reducer(
+      next,
+      messagePatched({
+        chatId: '1',
+        messageId: '10',
+        message: testMessage('10', 'client-10', { isDeleted: true, message: null }),
+      }),
+    );
+
+    // Message removed from timeline
+    expect(ids(selectActiveTimelineMessages(testRootState(next), '1'))).toEqual(['11']);
+  });
+
+  it('cleans up empty segments after deletion', () => {
+    let next = reducer(
+      undefined,
+      insertAround({
+        chatId: '1',
+        targetMessageId: '10',
+        messages: [testMessage('10')],
+        olderCursor: '10',
+        newerCursor: '10',
+      }),
+    );
+
+    // Delete the only message in the segment
+    next = reducer(
+      next,
+      messagePatched({
+        chatId: '1',
+        messageId: '10',
+        message: testMessage('10', 'client-10', { isDeleted: true, message: null }),
+      }),
+    );
+
+    // Segment should be cleaned up
+    expect(next.chats['1'].segments).toHaveLength(0);
+  });
+
+  it('preserves forwardedFrom when message is added via messageAdded', () => {
+    const forwardedMessage = testMessage('20', 'client-20', {
+      forwardedFrom: {
+        sender: { uid: 99, name: 'OriginalSender', gender: 0 },
+        originalChatId: 'other-chat',
+        originalMessageId: 'orig-1',
+      },
+    });
+
+    let next = reducer(
+      undefined,
+      refreshLatest({ chatId: '1', messages: [testMessage('10')], olderCursor: '10', newerCursor: null }),
+    );
+    next = reducer(
+      next,
+      messageAdded({ chatId: '1', storeChatId: '1', message: forwardedMessage, origin: 'ws', scope: 'main' }),
+    );
+
+    const messages = selectActiveTimelineMessages(testRootState(next), '1');
+    const fwd = messages.find((m) => m.id === '20');
+    expect(fwd?.forwardedFrom).toBeDefined();
+    expect(fwd?.forwardedFrom?.sender.name).toBe('OriginalSender');
+    expect(fwd?.forwardedFrom?.originalChatId).toBe('other-chat');
+  });
+
+  it('preserves forwardedFrom when message is loaded via refreshLatest', () => {
+    const forwardedMessage = testMessage('20', 'client-20', {
+      forwardedFrom: {
+        sender: { uid: 99, name: 'OriginalSender', gender: 0 },
+        originalChatId: 'other-chat',
+        originalMessageId: 'orig-1',
+      },
+    });
+
+    const next = reducer(
+      undefined,
+      refreshLatest({ chatId: '1', messages: [forwardedMessage], olderCursor: null, newerCursor: null }),
+    );
+
+    const messages = selectActiveTimelineMessages(testRootState(next), '1');
+    expect(messages[0].forwardedFrom).toBeDefined();
+    expect(messages[0].forwardedFrom?.sender.name).toBe('OriginalSender');
+    expect(messages[0].forwardedFrom?.originalChatId).toBe('other-chat');
+  });
+
+  it('preserves reactions and replyTo when a non-delete patch omits them', () => {
+    const base = testMessage('30', 'client-30', {
+      reactions: [{ emoji: '👍', count: 1, users: [{ uid: 1 }] }] as any,
+      replyToMessage: {
+        id: '10',
+        senderName: 'A',
+        message: 'hi',
+        messageType: 'text',
+        isDeleted: false,
+      } as any,
+    });
+    let next = reducer(
+      undefined,
+      refreshLatest({ chatId: '1', messages: [base], olderCursor: null, newerCursor: null }),
+    );
+    // Patch carries only id + body; reactions/replyToMessage are absent (undefined),
+    // so the `??` fallbacks must restore the originals (regression guard for M7).
+    next = reducer(
+      next,
+      messagePatched({
+        chatId: '1',
+        messageId: '30',
+        message: { id: '30', message: 'edited', messageType: 'text' } as any,
+      }),
+    );
+    const msg = selectActiveTimelineMessages(testRootState(next), '1').find((m) => m.id === '30')!;
+    expect(msg.message).toBe('edited');
+    expect(msg.reactions).toHaveLength(1);
+    expect(msg.replyToMessage?.id).toBe('10');
+  });
+
+  it('preserves forwardedFrom when a forwarded message is patched (edit)', () => {
+    const forwarded = testMessage('40', 'client-40', {
+      forwardedFrom: {
+        sender: { uid: 99, name: 'OriginalSender', gender: 0 },
+        originalChatId: 'other-chat',
+        originalMessageId: 'orig-1',
+      },
+    });
+    let next = reducer(
+      undefined,
+      refreshLatest({ chatId: '1', messages: [forwarded], olderCursor: null, newerCursor: null }),
+    );
+    // Edit the forwarded message body; forwardedFrom must survive because the patch omits it.
+    next = reducer(
+      next,
+      messagePatched({
+        chatId: '1',
+        messageId: '40',
+        message: { id: '40', message: 'edited forward', messageType: 'text' } as any,
+      }),
+    );
+    const msg = selectActiveTimelineMessages(testRootState(next), '1').find((m) => m.id === '40')!;
+    expect(msg.message).toBe('edited forward');
+    expect(msg.forwardedFrom).toBeDefined();
+    expect(msg.forwardedFrom?.sender.name).toBe('OriginalSender');
+  });
 });

--- a/wetty-chat-mobile/src/store/messages/storeIntegration.test.ts
+++ b/wetty-chat-mobile/src/store/messages/storeIntegration.test.ts
@@ -5,7 +5,7 @@ import { createStore, type RootState } from '../index';
 import { selectAllChats, selectChatUnreadCount } from '../chatsSlice';
 import { messageAdded, messagePatched, messagesBulkDeleted } from '../messageEvents';
 import { selectThreadSubscriptionStatus, selectThreads, setThreadsList } from '../threadsSlice';
-import { insertAround } from './slice';
+import { insertAround, updateThreadReplyCount } from './slice';
 import {
   selectActiveTimelineMessages,
   selectCanLoadNewer,
@@ -159,5 +159,84 @@ describe('message listener projections', () => {
       attachments: [],
       mentions: [],
     });
+  });
+
+  it('removes thread root placeholder when all replies are deleted and root is then deleted', async () => {
+    const store = createStore();
+
+    // Load a thread root with threadInfo
+    store.dispatch(
+      insertAround({
+        chatId: '1',
+        targetMessageId: '10',
+        messages: [testMessage('10', 'client-10', { threadInfo: { replyCount: 1 } }), testMessage('11')],
+        olderCursor: '10',
+        newerCursor: null,
+      }),
+    );
+    store.dispatch(setThreadsList({ threads: [subscribedThread()], nextCursor: null }));
+
+    // Delete the root (it should stay as placeholder because threadInfo exists)
+    store.dispatch(
+      messagePatched({
+        chatId: '1',
+        messageId: '10',
+        message: testMessage('10', 'client-10', { isDeleted: true, message: null, threadInfo: { replyCount: 1 } }),
+      }),
+    );
+    await Promise.resolve();
+
+    // Root is placeholder
+    let messages = selectActiveTimelineMessages(store.getState() as RootState, '1');
+    expect(ids(messages)).toContain('10');
+    expect(messages.find((m) => m.id === '10')?.isDeleted).toBe(true);
+
+    // All replies deleted → replyCount becomes 0 → threadInfo removed
+    store.dispatch(updateThreadReplyCount({ chatId: '1', threadRootId: '10', replyCount: 0 }));
+    await Promise.resolve();
+
+    // Root no longer has threadInfo, but is still in timeline (isDeleted + no threadInfo)
+    // Now the server sends messagePatched to fully remove it
+    store.dispatch(
+      messagePatched({
+        chatId: '1',
+        messageId: '10',
+        message: testMessage('10', 'client-10', { isDeleted: true, message: null, threadInfo: null as any }),
+      }),
+    );
+    await Promise.resolve();
+
+    // Root should be removed from timeline
+    messages = selectActiveTimelineMessages(store.getState() as RootState, '1');
+    expect(ids(messages)).not.toContain('10');
+  });
+
+  it('removes thread root when threadInfo is explicitly set to null via messagePatched', async () => {
+    const store = createStore();
+
+    // Load thread root with threadInfo
+    store.dispatch(
+      insertAround({
+        chatId: '1',
+        targetMessageId: '10',
+        messages: [testMessage('10', 'client-10', { threadInfo: { replyCount: 3 } }), testMessage('11')],
+        olderCursor: '10',
+        newerCursor: null,
+      }),
+    );
+
+    // Server says threadInfo is null (thread deleted server-side)
+    store.dispatch(
+      messagePatched({
+        chatId: '1',
+        messageId: '10',
+        message: testMessage('10', 'client-10', { isDeleted: true, message: null, threadInfo: null as any }),
+      }),
+    );
+    await Promise.resolve();
+
+    // Root removed because threadInfo is null/falsy
+    const messages = selectActiveTimelineMessages(store.getState() as RootState, '1');
+    expect(ids(messages)).not.toContain('10');
   });
 });

--- a/wetty-chat-mobile/src/store/threadsSlice.test.ts
+++ b/wetty-chat-mobile/src/store/threadsSlice.test.ts
@@ -1,0 +1,406 @@
+import { describe, expect, it } from 'vitest';
+import type { ThreadListItem } from '@/api/threads';
+import reducer, {
+  appendThreads,
+  clearThreads,
+  incrementThreadUnread,
+  markThreadRead,
+  patchThreadCachedLastReply,
+  patchThreadRootMessage,
+  removeThread,
+  selectActiveThreads,
+  selectArchivedThreads,
+  selectShouldShowThreadsRow,
+  selectThreadArchivedStatus,
+  selectThreadSubscriptionStatus,
+  selectThreadUnreadCount,
+  selectThreads,
+  selectTotalArchivedUnreadThreadCount,
+  selectTotalUnreadThreadCount,
+  selectThreadsWithUnreadCount,
+  selectArchivedThreadsWithUnreadCount,
+  setThreadReadState,
+  setThreadSubscriptionStatus,
+  setThreadsList,
+  updateThreadCachedLastReply,
+  updateThreadFromWs,
+} from './threadsSlice';
+import type { RootState } from './index';
+
+function makeThread(id: string, overrides: Partial<ThreadListItem> = {}): ThreadListItem {
+  return {
+    chatId: '1',
+    chatName: 'Chat',
+    chatAvatar: null,
+    threadRootMessage: {
+      id,
+      clientGeneratedId: `client-${id}`,
+      createdAt: new Date(Number(id)).toISOString(),
+      message: `root ${id}`,
+      messageType: 'text',
+      sender: { uid: 2, name: 'User', gender: 0 },
+      isDeleted: false,
+    },
+    participants: [{ uid: 2, name: 'User', gender: 0 }],
+    lastReply: null,
+    replyCount: 1,
+    lastReplyAt: new Date(Number(id)).toISOString(),
+    unreadCount: 0,
+    lastReadMessageId: null,
+    subscribedAt: new Date(Number(id)).toISOString(),
+    archived: false,
+    ...overrides,
+  };
+}
+
+function rootState(state: ReturnType<typeof reducer>): RootState {
+  return { threads: state } as unknown as RootState;
+}
+
+describe('threadsSlice reducers', () => {
+  it('setThreadsList replaces the target bucket and updates subscription map', () => {
+    const state = reducer(
+      undefined,
+      setThreadsList({ threads: [makeThread('10'), makeThread('11')], nextCursor: null }),
+    );
+
+    expect(selectThreads(rootState(state))).toHaveLength(2);
+    expect(state.buckets.active.isLoaded).toBe(true);
+    expect(state.subscriptionByThreadId['10']).toBe(true);
+    expect(state.subscriptionByThreadId['11']).toBe(true);
+    expect(state.archivedByThreadId['10']).toBe(false);
+  });
+
+  it('setThreadsList with archived=true replaces archived bucket while preserving active', () => {
+    let state = reducer(undefined, setThreadsList({ threads: [makeThread('10')], nextCursor: null }));
+    state = reducer(
+      state,
+      setThreadsList({ threads: [makeThread('20', { archived: true })], nextCursor: null, archived: true }),
+    );
+
+    expect(selectActiveThreads(rootState(state))).toHaveLength(1);
+    expect(selectArchivedThreads(rootState(state))).toHaveLength(1);
+    expect(state.buckets.archived.isLoaded).toBe(true);
+  });
+
+  it('setThreadsList with archived=true removes stale archived entries', () => {
+    let state = reducer(
+      undefined,
+      setThreadsList({ threads: [makeThread('10', { archived: true })], nextCursor: null, archived: true }),
+    );
+    state = reducer(
+      state,
+      setThreadsList({ threads: [makeThread('20', { archived: true })], nextCursor: null, archived: true }),
+    );
+
+    const archived = selectArchivedThreads(rootState(state));
+    expect(archived).toHaveLength(1);
+    expect(archived[0].threadRootMessage.id).toBe('20');
+  });
+
+  it('appendThreads deduplicates by thread root id', () => {
+    let state = reducer(undefined, setThreadsList({ threads: [makeThread('10')], nextCursor: null }));
+    state = reducer(state, appendThreads({ threads: [makeThread('10'), makeThread('11')], nextCursor: null }));
+
+    expect(selectThreads(rootState(state))).toHaveLength(2);
+  });
+
+  it('appendThreads updates cursor and subscription map', () => {
+    let state = reducer(undefined, setThreadsList({ threads: [makeThread('10')], nextCursor: null }));
+    state = reducer(state, appendThreads({ threads: [makeThread('11')], nextCursor: 'cursor-11' }));
+
+    expect(state.buckets.active.nextCursor).toBe('cursor-11');
+    expect(state.subscriptionByThreadId['11']).toBe(true);
+  });
+
+  it('updateThreadFromWs moves thread to top and updates replyCount', () => {
+    let state = reducer(undefined, setThreadsList({ threads: [makeThread('10'), makeThread('11')], nextCursor: null }));
+    state = reducer(
+      state,
+      updateThreadFromWs({ threadRootId: '10', chatId: '1', lastReplyAt: '2025-01-01', replyCount: 5 }),
+    );
+
+    expect(selectThreads(rootState(state))[0].threadRootMessage.id).toBe('10');
+    expect(selectThreads(rootState(state))[0].replyCount).toBe(5);
+  });
+
+  it('updateThreadFromWs removes thread when replyCount is 0', () => {
+    let state = reducer(undefined, setThreadsList({ threads: [makeThread('10'), makeThread('11')], nextCursor: null }));
+    state = reducer(
+      state,
+      updateThreadFromWs({ threadRootId: '10', chatId: '1', lastReplyAt: '2025-01-01', replyCount: 0 }),
+    );
+
+    expect(selectThreads(rootState(state))).toHaveLength(1);
+    expect(selectThreads(rootState(state))[0].threadRootMessage.id).toBe('11');
+    expect(state.subscriptionByThreadId['10']).toBe(false);
+    expect(state.archivedByThreadId['10']).toBeUndefined();
+  });
+
+  it('updateThreadFromWs does nothing for unknown thread', () => {
+    const state = reducer(undefined, setThreadsList({ threads: [makeThread('10')], nextCursor: null }));
+    const next = reducer(
+      state,
+      updateThreadFromWs({ threadRootId: '999', chatId: '1', lastReplyAt: '2025-01-01', replyCount: 5 }),
+    );
+
+    expect(selectThreads(rootState(next))).toHaveLength(1);
+  });
+
+  it('updateThreadCachedLastReply updates the cached preview', () => {
+    let state = reducer(undefined, setThreadsList({ threads: [makeThread('10')], nextCursor: null }));
+    const preview = { ...makeThread('10').threadRootMessage, id: 'reply-1', message: 'last reply' };
+    state = reducer(state, updateThreadCachedLastReply({ threadRootId: '10', cachedLastReply: preview }));
+
+    expect(state.items[0].cachedLastReply?.message).toBe('last reply');
+  });
+
+  it('patchThreadCachedLastReply partially updates the cached preview', () => {
+    let state = reducer(undefined, setThreadsList({ threads: [makeThread('10')], nextCursor: null }));
+    const preview = { ...makeThread('10').threadRootMessage, id: 'reply-1', message: 'last reply' };
+    state = reducer(state, updateThreadCachedLastReply({ threadRootId: '10', cachedLastReply: preview }));
+    state = reducer(
+      state,
+      patchThreadCachedLastReply({ threadRootId: '10', patch: { isDeleted: true, message: null } }),
+    );
+
+    expect(state.items[0].cachedLastReply?.isDeleted).toBe(true);
+    expect(state.items[0].cachedLastReply?.message).toBeNull();
+  });
+
+  it('patchThreadCachedLastReply does nothing for unknown thread', () => {
+    const state = reducer(undefined, setThreadsList({ threads: [makeThread('10')], nextCursor: null }));
+    const next = reducer(state, patchThreadCachedLastReply({ threadRootId: '999', patch: { isDeleted: true } }));
+
+    expect(next).toBe(state);
+  });
+
+  it('incrementThreadUnread increments unreadCount', () => {
+    let state = reducer(undefined, setThreadsList({ threads: [makeThread('10')], nextCursor: null }));
+    state = reducer(state, incrementThreadUnread({ threadRootId: '10' }));
+    state = reducer(state, incrementThreadUnread({ threadRootId: '10' }));
+
+    expect(selectThreadUnreadCount(rootState(state), '10')).toBe(2);
+  });
+
+  it('markThreadRead resets unreadCount to 0', () => {
+    let state = reducer(
+      undefined,
+      setThreadsList({ threads: [makeThread('10', { unreadCount: 5 })], nextCursor: null }),
+    );
+    state = reducer(state, markThreadRead({ threadRootId: '10' }));
+
+    expect(selectThreadUnreadCount(rootState(state), '10')).toBe(0);
+  });
+
+  it('setThreadReadState updates lastReadMessageId and unreadCount', () => {
+    let state = reducer(undefined, setThreadsList({ threads: [makeThread('10')], nextCursor: null }));
+    state = reducer(state, setThreadReadState({ threadRootId: '10', lastReadMessageId: 'msg-5', unreadCount: 3 }));
+
+    expect(state.items[0].lastReadMessageId).toBe('msg-5');
+    expect(state.items[0].unreadCount).toBe(3);
+  });
+
+  it('setThreadSubscriptionStatus updates subscription and archived maps', () => {
+    let state = reducer(undefined, setThreadsList({ threads: [makeThread('10')], nextCursor: null }));
+    state = reducer(state, setThreadSubscriptionStatus({ threadRootId: '10', subscribed: true, archived: true }));
+
+    expect(selectThreadSubscriptionStatus(rootState(state), '10')).toBe(true);
+    expect(selectThreadArchivedStatus(rootState(state), '10')).toBe(true);
+    expect(state.items[0].archived).toBe(true);
+  });
+
+  it('setThreadSubscriptionStatus without archived only updates subscription', () => {
+    let state = reducer(undefined, setThreadsList({ threads: [makeThread('10')], nextCursor: null }));
+    state = reducer(state, setThreadSubscriptionStatus({ threadRootId: '10', subscribed: false }));
+
+    expect(selectThreadSubscriptionStatus(rootState(state), '10')).toBe(false);
+  });
+
+  it('removeThread removes thread from items and resets maps', () => {
+    let state = reducer(undefined, setThreadsList({ threads: [makeThread('10'), makeThread('11')], nextCursor: null }));
+    state = reducer(state, removeThread({ threadRootId: '10' }));
+
+    expect(selectThreads(rootState(state))).toHaveLength(1);
+    expect(selectThreads(rootState(state))[0].threadRootMessage.id).toBe('11');
+    expect(state.subscriptionByThreadId['10']).toBe(false);
+    expect(state.archivedByThreadId['10']).toBeUndefined();
+  });
+
+  it('patchThreadRootMessage partially updates threadRootMessage', () => {
+    let state = reducer(undefined, setThreadsList({ threads: [makeThread('10')], nextCursor: null }));
+    state = reducer(state, patchThreadRootMessage({ threadRootId: '10', message: { isDeleted: true, message: null } }));
+
+    expect(state.items[0].threadRootMessage.isDeleted).toBe(true);
+    expect(state.items[0].threadRootMessage.message).toBeNull();
+  });
+
+  it('clearThreads resets all state to initial', () => {
+    let state = reducer(undefined, setThreadsList({ threads: [makeThread('10')], nextCursor: 'cursor' }));
+    state = reducer(state, clearThreads());
+
+    expect(state.items).toEqual([]);
+    expect(state.buckets.active).toEqual({ nextCursor: null, isLoaded: false });
+    expect(state.buckets.archived).toEqual({ nextCursor: null, isLoaded: false });
+    expect(state.subscriptionByThreadId).toEqual({});
+    expect(state.archivedByThreadId).toEqual({});
+  });
+});
+
+describe('threadsSlice selectors', () => {
+  it('selectActiveThreads filters out archived threads', () => {
+    const state = rootState(
+      reducer(
+        undefined,
+        setThreadsList({
+          threads: [makeThread('10'), makeThread('11', { archived: true })],
+          nextCursor: null,
+          archived: true,
+        }),
+      ),
+    );
+    // Need to add active threads too
+    const fullState = rootState(
+      reducer(
+        (state as unknown as RootState).threads,
+        setThreadsList({ threads: [makeThread('10')], nextCursor: null }),
+      ),
+    );
+
+    expect(selectActiveThreads(fullState)).toHaveLength(1);
+    expect(selectActiveThreads(fullState)[0].threadRootMessage.id).toBe('10');
+  });
+
+  it('selectArchivedThreads filters to only archived threads', () => {
+    const state = rootState(
+      reducer(
+        reducer(undefined, setThreadsList({ threads: [makeThread('10')], nextCursor: null })),
+        setThreadsList({ threads: [makeThread('20', { archived: true })], nextCursor: null, archived: true }),
+      ),
+    );
+
+    expect(selectArchivedThreads(state)).toHaveLength(1);
+    expect(selectArchivedThreads(state)[0].threadRootMessage.id).toBe('20');
+  });
+
+  it('selectTotalUnreadThreadCount sums active thread unread counts', () => {
+    const state = rootState(
+      reducer(
+        undefined,
+        setThreadsList({
+          threads: [
+            makeThread('10', { unreadCount: 3 }),
+            makeThread('11', { unreadCount: 2 }),
+            makeThread('12', { unreadCount: 5, archived: true }),
+          ],
+          nextCursor: null,
+        }),
+      ),
+    );
+
+    expect(selectTotalUnreadThreadCount(state)).toBe(5);
+  });
+
+  it('selectTotalArchivedUnreadThreadCount sums archived thread unread counts', () => {
+    const state = rootState(
+      reducer(
+        reducer(undefined, setThreadsList({ threads: [makeThread('10', { unreadCount: 3 })], nextCursor: null })),
+        setThreadsList({
+          threads: [makeThread('20', { unreadCount: 7, archived: true })],
+          nextCursor: null,
+          archived: true,
+        }),
+      ),
+    );
+
+    expect(selectTotalArchivedUnreadThreadCount(state)).toBe(7);
+  });
+
+  it('selectThreadsWithUnreadCount counts active threads with unread > 0', () => {
+    const state = rootState(
+      reducer(
+        undefined,
+        setThreadsList({
+          threads: [
+            makeThread('10', { unreadCount: 3 }),
+            makeThread('11', { unreadCount: 0 }),
+            makeThread('12', { unreadCount: 1 }),
+          ],
+          nextCursor: null,
+        }),
+      ),
+    );
+
+    expect(selectThreadsWithUnreadCount(state)).toBe(2);
+  });
+
+  it('selectArchivedThreadsWithUnreadCount counts archived threads with unread > 0', () => {
+    const state = rootState(
+      reducer(
+        reducer(undefined, setThreadsList({ threads: [makeThread('10')], nextCursor: null })),
+        setThreadsList({
+          threads: [
+            makeThread('20', { unreadCount: 2, archived: true }),
+            makeThread('21', { unreadCount: 0, archived: true }),
+          ],
+          nextCursor: null,
+          archived: true,
+        }),
+      ),
+    );
+
+    expect(selectArchivedThreadsWithUnreadCount(state)).toBe(1);
+  });
+
+  it('selectThreadSubscriptionStatus returns boolean for known thread, null for unknown', () => {
+    let state = rootState(reducer(undefined, setThreadsList({ threads: [makeThread('10')], nextCursor: null })));
+    state = rootState(reducer(state.threads, setThreadSubscriptionStatus({ threadRootId: '10', subscribed: true })));
+
+    expect(selectThreadSubscriptionStatus(state, '10')).toBe(true);
+    expect(selectThreadSubscriptionStatus(state, '999')).toBeNull();
+  });
+
+  it('selectThreadUnreadCount returns count for known thread, 0 for unknown', () => {
+    const state = rootState(
+      reducer(undefined, setThreadsList({ threads: [makeThread('10', { unreadCount: 5 })], nextCursor: null })),
+    );
+
+    expect(selectThreadUnreadCount(state, '10')).toBe(5);
+    expect(selectThreadUnreadCount(state, '999')).toBe(0);
+  });
+
+  it('selectThreadArchivedStatus returns boolean for known thread, null for unknown', () => {
+    const state = rootState(
+      reducer(
+        reducer(undefined, setThreadsList({ threads: [makeThread('10')], nextCursor: null })),
+        setThreadsList({ threads: [makeThread('20', { archived: true })], nextCursor: null, archived: true }),
+      ),
+    );
+
+    expect(selectThreadArchivedStatus(state, '20')).toBe(true);
+    expect(selectThreadArchivedStatus(state, '10')).toBe(false);
+    expect(selectThreadArchivedStatus(state, '999')).toBeNull();
+  });
+
+  it('selectShouldShowThreadsRow returns true when there are unread threads', () => {
+    const state = rootState(
+      reducer(undefined, setThreadsList({ threads: [makeThread('10', { unreadCount: 1 })], nextCursor: null })),
+    );
+
+    expect(selectShouldShowThreadsRow(state)).toBe(true);
+  });
+
+  it('selectShouldShowThreadsRow returns true when threads are loaded and active threads exist', () => {
+    const state = rootState(
+      reducer(undefined, setThreadsList({ threads: [makeThread('10', { unreadCount: 0 })], nextCursor: null })),
+    );
+
+    expect(selectShouldShowThreadsRow(state)).toBe(true);
+  });
+
+  it('selectShouldShowThreadsRow returns false when no unread and no loaded threads', () => {
+    const state = rootState(reducer(undefined, { type: 'init' } as any));
+
+    expect(selectShouldShowThreadsRow(state)).toBe(false);
+  });
+});


### PR DESCRIPTION
This PR introduces Telegram-style single message forwarding, implements part of #181

- Added a "Forward" button to the message context menu. Clicking it opens a modal listing all unarchived chats, sorted by recent activity.
- Forwarded messages (except stickers) will display the original sender's username. For chained forwards (forwarding an already forwarded message), it always traces back and shows the original sender, not the intermediate one.
- Forwarding a message with attachments only references the original file without duplicating it on the server.

Not included in this PR:
- Combined/merged forwarding (currently being worked on by @Codetector1374 
- Multi-select forwarding (temporarily put on hold after discussion due to complex chronological order issues).