### PR TITLE
fix(backend,pwa): Handle deleted messages in threads

### DIFF
--- a/backend/src/handlers/chats/messages.rs
+++ b/backend/src/handlers/chats/messages.rs
@@ -640,22 +640,30 @@ pub(super) async fn post_thread_message(
     check_membership(conn, chat_id, uid)?;
     validate_client_message_type(&body.message_type)?;
 
-    // Load root message: validate existence and message type
+    // Load root message: validate existence. Allow deleted roots only when a
+    // thread already exists (has_thread=true) so existing discussions stay usable.
+    // A deleted message with has_thread=false means the discussion is fully
+    // terminated, so it's excluded here and surfaces as NotFound.
 
     let root_msg: Message = messages::table
         .filter(
             dsl::id
                 .eq(thread_id)
                 .and(dsl::chat_id.eq(chat_id))
-                .and(dsl::deleted_at.is_null())
-                .and(dsl::is_published.eq(true)),
+                .and(dsl::is_published.eq(true))
+                .and(dsl::deleted_at.is_null().or(dsl::has_thread.eq(true))),
         )
         .select(Message::as_select())
         .first(conn)
         .optional()?
         .ok_or(AppError::NotFound("Thread root message not found"))?;
 
-    if root_msg.message_type != MessageType::Text {
+    // Skip message-type check for deleted roots - the thread already exists.
+    // Invariant: only Text messages can ever acquire has_thread=true (enforced in
+    // post_thread_message above), so a deleted root is guaranteed to be Text and
+    // does not need re-validation. We skip solely because message_type is not
+    // reliable for deleted rows that may have been redacted.
+    if root_msg.deleted_at.is_none() && root_msg.message_type != MessageType::Text {
         return Err(AppError::BadRequest(
             "Threads can only be created on text messages",
         ));
@@ -1051,6 +1059,9 @@ async fn delete_message(
     let ws_msg = std::sync::Arc::new(ServerWsMessage::MessageDeleted(response.clone()));
     state.ws_registry.broadcast_to_uids(&member_uids, ws_msg);
 
+    // Thread reply deletion: broadcast the lighter ThreadUpdate (carries reply_count /
+    // last_reply_at) to subscribers for the thread-list view. The parent-chat bubble
+    // badge is refreshed for ALL members by the MessageUpdated(root) broadcast below.
     if let Some(reply_root_id) = response.reply_root_id {
         if let Err(err) = crate::services::threads::broadcast_thread_update_to_subscribers(
             conn,
@@ -1064,6 +1075,30 @@ async fn delete_message(
                 ?err,
                 "failed to broadcast thread update after reply deletion"
             );
+        }
+    }
+
+    // Broadcast the updated root message to ALL members so the thread-reply
+    // count badge (threadInfo.replyCount) decreases in real-time — mirrors the
+    // reply-create path which broadcasts MessageUpdated(root) to all members.
+    // The ThreadUpdate above only reaches subscribed users; the bubble audience
+    // is all members viewing the parent timeline, many of whom are not
+    // subscribed (thread view does not set subscribed=true).
+    if let Some(reply_root_id) = response.reply_root_id {
+        let root_msg_updated: Option<Message> = messages::table
+            .filter(dsl::id.eq(reply_root_id).and(dsl::chat_id.eq(chat_id)))
+            .select(Message::as_select())
+            .first(conn)
+            .ok();
+        if let Some(root_msg) = root_msg_updated {
+            let root_response = attach_metadata(conn, vec![root_msg], &state, uid)
+                .await
+                .into_iter()
+                .next();
+            if let Some(root_response) = root_response {
+                let ws_msg = std::sync::Arc::new(ServerWsMessage::MessageUpdated(root_response));
+                state.ws_registry.broadcast_to_uids(&member_uids, ws_msg);
+            }
         }
     }
 

--- a/backend/src/handlers/chats/messages.rs
+++ b/backend/src/handlers/chats/messages.rs
@@ -658,12 +658,7 @@ pub(super) async fn post_thread_message(
         .optional()?
         .ok_or(AppError::NotFound("Thread root message not found"))?;
 
-    // Skip message-type check for deleted roots - the thread already exists.
-    // Invariant: only Text messages can ever acquire has_thread=true (enforced in
-    // post_thread_message above), so a deleted root is guaranteed to be Text and
-    // does not need re-validation. We skip solely because message_type is not
-    // reliable for deleted rows that may have been redacted.
-    if root_msg.deleted_at.is_none() && root_msg.message_type != MessageType::Text {
+    if root_msg.message_type != MessageType::Text {
         return Err(AppError::BadRequest(
             "Threads can only be created on text messages",
         ));

--- a/backend/src/handlers/chats/mod.rs
+++ b/backend/src/handlers/chats/mod.rs
@@ -468,8 +468,14 @@ pub(crate) fn redact_deleted_message_response(response: &mut MessageResponse) {
     response.sticker = None;
     response.has_attachments = false;
     response.attachments.clear();
-    response.reactions.clear();
     response.mentions.clear();
+
+    // Keep reactions only on deleted thread roots — those threads remain visible and
+    // reactions belong to other users. For ordinary deleted messages, clear reactions
+    // (they are no longer reachable and should not leak).
+    if response.thread_info.is_none() {
+        response.reactions.clear();
+    }
 }
 
 fn sticker_preview_text(emoji: Option<&str>) -> String {
@@ -1192,11 +1198,7 @@ pub async fn attach_metadata(
             },
             reply_to_message,
             attachments,
-            reactions: if is_deleted {
-                Vec::new()
-            } else {
-                reaction_summaries_map.remove(&m.id).unwrap_or_default()
-            },
+            reactions: reaction_summaries_map.remove(&m.id).unwrap_or_default(),
             mentions: {
                 per_message_mentions[idx]
                     .iter()
@@ -2326,7 +2328,9 @@ mod tests {
         assert!(response.sticker.is_none());
         assert!(!response.has_attachments);
         assert!(response.attachments.is_empty());
-        assert!(response.reactions.is_empty());
+        // This deleted message is a thread root (thread_info present), so reactions are
+        // intentionally preserved per the targeted redaction policy.
+        assert_eq!(response.reactions.len(), 1);
         assert!(response.mentions.is_empty());
     }
 

--- a/backend/src/handlers/chats/mod.rs
+++ b/backend/src/handlers/chats/mod.rs
@@ -468,14 +468,8 @@ pub(crate) fn redact_deleted_message_response(response: &mut MessageResponse) {
     response.sticker = None;
     response.has_attachments = false;
     response.attachments.clear();
+    response.reactions.clear();
     response.mentions.clear();
-
-    // Keep reactions only on deleted thread roots — those threads remain visible and
-    // reactions belong to other users. For ordinary deleted messages, clear reactions
-    // (they are no longer reachable and should not leak).
-    if response.thread_info.is_none() {
-        response.reactions.clear();
-    }
 }
 
 fn sticker_preview_text(emoji: Option<&str>) -> String {
@@ -2328,9 +2322,7 @@ mod tests {
         assert!(response.sticker.is_none());
         assert!(!response.has_attachments);
         assert!(response.attachments.is_empty());
-        // This deleted message is a thread root (thread_info present), so reactions are
-        // intentionally preserved per the targeted redaction policy.
-        assert_eq!(response.reactions.len(), 1);
+        assert!(response.reactions.is_empty());
         assert!(response.mentions.is_empty());
     }
 

--- a/backend/src/handlers/chats/reactions.rs
+++ b/backend/src/handlers/chats/reactions.rs
@@ -141,11 +141,15 @@ async fn get_reaction_details(
     let conn = &mut *conn;
     check_membership(conn, chat_id, uid)?;
 
-    // Verify message exists in this chat
+    // Verify message exists in this chat (allow deleted messages with threads to show existing reactions)
     let _message: Message = messages::table
         .filter(messages::id.eq(message_id))
         .filter(messages::chat_id.eq(chat_id))
-        .filter(messages::deleted_at.is_null())
+        .filter(
+            messages::deleted_at
+                .is_null()
+                .or(messages::has_thread.eq(true)),
+        )
         .filter(messages::is_published.eq(true))
         .first(conn)
         .optional()?
@@ -281,6 +285,16 @@ async fn delete_reaction(
     let conn = &mut *conn;
     let emoji = validate_emoji(&emoji)?;
     check_membership(conn, chat_id, uid)?;
+
+    // Verify message exists and is not deleted (no reaction removal on deleted messages)
+    let _message: Message = messages::table
+        .filter(messages::id.eq(message_id))
+        .filter(messages::chat_id.eq(chat_id))
+        .filter(messages::deleted_at.is_null())
+        .filter(messages::is_published.eq(true))
+        .first(conn)
+        .optional()?
+        .ok_or(AppError::NotFound("Message not found"))?;
 
     let deleted = diesel::delete(
         message_reactions::table

--- a/backend/src/handlers/chats/reactions.rs
+++ b/backend/src/handlers/chats/reactions.rs
@@ -141,15 +141,11 @@ async fn get_reaction_details(
     let conn = &mut *conn;
     check_membership(conn, chat_id, uid)?;
 
-    // Verify message exists in this chat (allow deleted messages with threads to show existing reactions)
+    // Reactions are not exposed for deleted messages (even thread-root placeholders).
     let _message: Message = messages::table
         .filter(messages::id.eq(message_id))
         .filter(messages::chat_id.eq(chat_id))
-        .filter(
-            messages::deleted_at
-                .is_null()
-                .or(messages::has_thread.eq(true)),
-        )
+        .filter(messages::deleted_at.is_null())
         .filter(messages::is_published.eq(true))
         .first(conn)
         .optional()?

--- a/backend/src/services/background.rs
+++ b/backend/src/services/background.rs
@@ -304,9 +304,10 @@ fn process_bulk_delete(
                 continue;
             }
 
-            if let Err(e) = crate::services::threads::broadcast_thread_update_to_subscribers(
+            if let Err(e) = crate::services::threads::broadcast_thread_update_to_uids(
                 conn,
                 ws_registry,
+                &member_uids,
                 chat_id,
                 thread_root_id,
             ) {

--- a/backend/src/services/threads.rs
+++ b/backend/src/services/threads.rs
@@ -364,7 +364,7 @@ pub fn recalculate_thread_meta(
                 .execute(conn)?;
         }
         _ => {
-            // No active replies — remove the meta row
+            // No active replies — remove the meta row and reset has_thread
             diesel::delete(
                 thread_meta::table.filter(
                     thread_meta::chat_id
@@ -373,8 +373,13 @@ pub fn recalculate_thread_meta(
                 ),
             )
             .execute(conn)?;
+
+            diesel::update(messages::table.filter(messages::id.eq(thread_root_id)))
+                .set(messages::has_thread.eq(false))
+                .execute(conn)?;
         }
     }
+
     Ok(())
 }
 
@@ -389,7 +394,6 @@ pub fn build_thread_update_payload(
                 .eq(thread_root_id)
                 .and(messages::chat_id.eq(chat_id))
                 .and(messages::reply_root_id.is_null())
-                .and(messages::has_thread.eq(true))
                 .and(messages::is_published.eq(true)),
         )
         .select(messages::created_at)

--- a/wetty-chat-mobile/src/components/chat/messages/ChatBubbleBase.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/ChatBubbleBase.tsx
@@ -107,6 +107,7 @@ export interface ChatBubbleBaseProps {
   maxImageHeight?: number;
   reactions?: ReactionSummary[];
   onReactionToggle?: (emoji: string, currentlyReacted: boolean) => void;
+  reactionsInteractive?: boolean;
   layout?: 'thread' | 'bubble-only';
   interactionMode?: 'interactive' | 'read-only';
   bubbleProps?: BubblePropsOverride;
@@ -140,6 +141,7 @@ export function ChatBubbleBase({
   maxImageHeight = 300,
   reactions,
   onReactionToggle,
+  reactionsInteractive,
   layout = 'thread',
   interactionMode = 'interactive',
   bubbleProps,
@@ -500,7 +502,7 @@ export function ChatBubbleBase({
           key={reaction.emoji}
           reaction={reaction}
           isSent={isSent}
-          interactive={interactive}
+          interactive={reactionsInteractive ?? interactive}
           onToggle={onReactionToggle}
         />
       ))}

--- a/wetty-chat-mobile/src/components/chat/messages/ChatMessageRow.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/ChatMessageRow.tsx
@@ -196,6 +196,7 @@ function MessageBubble({
       attachments={msg.attachments}
       reactions={msg.reactions}
       onReactionToggle={(emoji, currentlyReacted) => onReactionToggle(msg, emoji, currentlyReacted)}
+      reactionsInteractive={!msg.isDeleted}
       mentions={msg.mentions}
       currentUserUid={typeof currentUserId === 'number' ? currentUserId : null}
       onMentionClick={(uid) => onAvatarClick(mentionToUser(msg.mentions, uid))}

--- a/wetty-chat-mobile/src/components/chat/messages/ReactionPill.module.scss
+++ b/wetty-chat-mobile/src/components/chat/messages/ReactionPill.module.scss
@@ -43,6 +43,14 @@
   color: var(--ion-color-primary-contrast);
 }
 
+.reactionPillReadOnly {
+  cursor: default;
+
+  &:active {
+    transform: none;
+  }
+}
+
 .reactionEmoji {
   margin: 0.5px 0 0.5px 6px;
   font-size: 18.5px;

--- a/wetty-chat-mobile/src/components/chat/messages/ReactionPill.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/ReactionPill.tsx
@@ -14,6 +14,7 @@ export function ReactionPill({ reaction, isSent = false, interactive = false, on
     reaction.reactedByMe ? styles.reactionPillActive : '',
     isSent ? styles.reactionPillSent : '',
     isSent && reaction.reactedByMe ? styles.reactionPillSentActive : '',
+    !interactive ? styles.reactionPillReadOnly : '',
   ]
     .filter(Boolean)
     .join(' ');

--- a/wetty-chat-mobile/src/pages/conversation/ConversationOverlayHost.tsx
+++ b/wetty-chat-mobile/src/pages/conversation/ConversationOverlayHost.tsx
@@ -94,13 +94,15 @@ export function ConversationOverlayHost({
               sourceRect: overlayMessage.sourceRect,
               interactionPos: overlayMessage.interactionPos,
               actions: overlayActions,
-              reactions: {
-                emojis: quickReactionEmojis,
-                currentMessageReactions: msg.reactions?.map((r) => r.emoji) ?? [],
-                onReact: (emoji: string) => {
-                  onReactionToggle(msg, emoji, !!msg.reactions?.some((r) => r.emoji === emoji && r.reactedByMe));
-                },
-              },
+              reactions: msg.isDeleted
+                ? undefined
+                : {
+                    emojis: quickReactionEmojis,
+                    currentMessageReactions: msg.reactions?.map((r) => r.emoji) ?? [],
+                    onReact: (emoji: string) => {
+                      onReactionToggle(msg, emoji, !!msg.reactions?.some((r) => r.emoji === emoji && r.reactedByMe));
+                    },
+                  },
               onClose: onCloseOverlay,
               mentions: msg.mentions ?? undefined,
               currentUserUid: currentUserId,

--- a/wetty-chat-mobile/src/pages/conversation/conversation.tsx
+++ b/wetty-chat-mobile/src/pages/conversation/conversation.tsx
@@ -195,6 +195,22 @@ function ConversationPane({ chatId, threadId, backAction }: ConversationPaneProp
     setOverlayMessage({ message, sourceRect, interactionPos });
   }, [keyboardFullyClosed]);
 
+  // Auto-redirect from thread view when the root message and all replies are deleted.
+  // When a deleted root loses its last reply, threadInfo is cleared → the message is
+  // removed from the timeline entirely. Track whether we've seen the root at least once
+  // to avoid redirecting during initial load before the API response arrives.
+  const hasSeenRootRef = useRef(false);
+  useEffect(() => {
+    if (!threadId) return;
+    const rootMessage = messageLookup.get(threadId);
+    if (rootMessage) {
+      hasSeenRootRef.current = true;
+    } else if (hasSeenRootRef.current) {
+      // Root was present before but is now gone — discussion terminated.
+      history.replace(`/chats/chat/${chatId}`);
+    }
+  }, [threadId, messageLookup, chatId, history]);
+
   useEffect(() => {
     if (!import.meta.env.DEV) return;
     console.log('[Conversation] rows-changed', {

--- a/wetty-chat-mobile/src/pages/conversation/utils/overlayActionPolicy.test.ts
+++ b/wetty-chat-mobile/src/pages/conversation/utils/overlayActionPolicy.test.ts
@@ -36,7 +36,7 @@ describe('overlay action policy', () => {
     expect(keys({ text: '', hasAttachments: true })).toEqual(['reply', 'thread', 'save', 'copy-link']);
   });
 
-  it('adds edit and delete for own regular messages even when optimistic or deleted', () => {
+  it('adds edit and delete for own regular messages, but not when deleted', () => {
     expect(keys({ isOwn: true, isOptimistic: true })).toEqual([
       'reply',
       'thread',
@@ -45,13 +45,7 @@ describe('overlay action policy', () => {
       'copy-link',
       'delete',
     ]);
-    expect(keys({ isOwn: true, isDeleted: true, text: null })).toEqual([
-      'reply',
-      'thread',
-      'edit',
-      'copy-link',
-      'delete',
-    ]);
+    expect(keys({ isOwn: true, isDeleted: true, text: null })).toEqual(['reply', 'copy-link']);
   });
 
   it('adds delete and pin state for admins in main chat', () => {
@@ -72,7 +66,7 @@ describe('overlay action policy', () => {
 
   it('preserves current optimistic and deleted save/pin restrictions', () => {
     expect(keys({ isOptimistic: true })).toEqual(['reply', 'thread', 'copy', 'copy-link']);
-    expect(keys({ isDeleted: true, text: null, isAdmin: true })).toEqual(['reply', 'thread', 'copy-link', 'delete']);
+    expect(keys({ isDeleted: true, text: null, isAdmin: true })).toEqual(['reply', 'copy-link']);
   });
 
   it('keeps sticker actions filtered to reply delete copy link and favorite', () => {

--- a/wetty-chat-mobile/src/pages/conversation/utils/overlayActionPolicy.ts
+++ b/wetty-chat-mobile/src/pages/conversation/utils/overlayActionPolicy.ts
@@ -42,7 +42,7 @@ export function getOverlayActionPolicy(input: OverlayActionPolicyInput): Overlay
   actions.push({ key: 'reply' });
 
   // 2. Thread
-  if (!input.isThreadView && !input.hasThreadInfo) {
+  if (!input.isThreadView && !input.hasThreadInfo && !input.isDeleted) {
     actions.push({ key: 'thread' });
   }
 
@@ -57,7 +57,7 @@ export function getOverlayActionPolicy(input: OverlayActionPolicyInput): Overlay
   }
 
   // 5. Edit
-  if (input.isOwn && !audioMessage && !stickerMessage) {
+  if (input.isOwn && !input.isDeleted && !audioMessage && !stickerMessage) {
     actions.push({ key: 'edit' });
   }
 
@@ -72,7 +72,7 @@ export function getOverlayActionPolicy(input: OverlayActionPolicyInput): Overlay
   actions.push({ key: 'copy-link' });
 
   // 8. Delete
-  if (input.isOwn || input.isAdmin) {
+  if ((input.isOwn || input.isAdmin) && !input.isDeleted) {
     actions.push({ key: 'delete' });
   }
 

--- a/wetty-chat-mobile/src/store/index.ts
+++ b/wetty-chat-mobile/src/store/index.ts
@@ -1,6 +1,7 @@
 import { combineReducers, configureStore, createListenerMiddleware } from '@reduxjs/toolkit';
 import connectionReducer from './connectionSlice';
-import messagesReducer from './messages/slice';
+import { getMessages } from '@/api/messages';
+import messagesReducer, { updateThreadReplyCount, refreshLatest } from './messages/slice';
 import settingsReducer, { type SettingsState } from './settingsSlice';
 import stickerPreferencesReducer, {
   hydrateStickerPreferencesFromKv,
@@ -18,6 +19,7 @@ import threadsReducer, {
   updateThreadCachedLastReply,
   patchThreadCachedLastReply,
   patchThreadRootMessage,
+  updateThreadFromWs,
 } from './threadsSlice';
 import chatsReducer, {
   projectChatMessageAdded,
@@ -209,6 +211,33 @@ listenerMiddleware.startListening({
             }),
           );
         }
+      }
+    }
+  },
+});
+
+listenerMiddleware.startListening({
+  actionCreator: updateThreadFromWs,
+  effect: async (action, api) => {
+    const { threadRootId, chatId, replyCount } = action.payload;
+    api.dispatch(updateThreadReplyCount({ chatId, threadRootId, replyCount }));
+
+    // When all replies are deleted and the thread is removed from the list,
+    // refresh the parent chat timeline so the root message's threadInfo is cleared.
+    if (replyCount === 0) {
+      try {
+        const res = await getMessages(chatId);
+        const list = res.data.messages ?? [];
+        api.dispatch(
+          refreshLatest({
+            chatId,
+            messages: list,
+            nextCursor: res.data.nextCursor ?? null,
+            prevCursor: null,
+          }),
+        );
+      } catch {
+        // silent — timeline will refresh on next visit
       }
     }
   },

--- a/wetty-chat-mobile/src/store/messages/slice.ts
+++ b/wetty-chat-mobile/src/store/messages/slice.ts
@@ -216,6 +216,28 @@ const messagesSlice = createSlice({
       failed.isDeleted = true;
       chat.generation++;
     },
+    updateThreadReplyCount(state, action: { payload: { chatId: string; threadRootId: string; replyCount: number } }) {
+      const { chatId, threadRootId, replyCount } = action.payload;
+      const chat = state.chats[chatId];
+      if (!chat) return;
+      for (const segment of chat.segments) {
+        for (let i = 0; i < segment.messages.length; i++) {
+          if (segment.messages[i].id === threadRootId && segment.messages[i].threadInfo) {
+            if (replyCount === 0) {
+              // Remove threadInfo so bubble renders as normal message
+              delete segment.messages[i].threadInfo;
+            } else {
+              segment.messages[i] = {
+                ...segment.messages[i],
+                threadInfo: { ...segment.messages[i].threadInfo, replyCount },
+              };
+            }
+            chat.generation++;
+            return;
+          }
+        }
+      }
+    },
   },
   extraReducers: (builder) => {
     builder
@@ -257,18 +279,37 @@ const messagesSlice = createSlice({
           }
           for (const segment of chat.segments) {
             if (message.isDeleted) {
-              segment.messages = segment.messages.filter((m) => m.id !== messageId);
+              // Thread root messages stay in timeline with isDeleted flag so the
+              // thread remains reachable; plain messages are removed.
+              const idx = segment.messages.findIndex((m) => m.id === messageId);
+              const existing = idx !== -1 ? segment.messages[idx] : undefined;
+              // Use explicit `!== undefined` so `null` from the server (thread_info: None)
+              // is respected instead of falling back to the stale local value via `??`.
+              const newThreadInfo =
+                existing && message.threadInfo !== undefined ? message.threadInfo : existing?.threadInfo;
+              if (existing && newThreadInfo) {
+                segment.messages[idx] = {
+                  ...existing,
+                  ...message,
+                  threadInfo: newThreadInfo,
+                };
+              } else {
+                segment.messages = segment.messages.filter((m) => m.id !== messageId);
+              }
             }
             for (let i = 0; i < segment.messages.length; i++) {
               const current = segment.messages[i];
               if (!message.isDeleted && current.id === messageId) {
-                segment.messages[i] = {
-                  ...current,
-                  ...message,
-                  replyToMessage: message.replyToMessage ?? current.replyToMessage,
-                  reactions: message.reactions ?? current.reactions,
-                  threadInfo: message.threadInfo ?? current.threadInfo,
-                };
+                // Capture originals before Object.assign; otherwise the `??` fallbacks
+                // below would read the already-overwritten value (`message.X ?? message.X`).
+                // threadInfo uses `!== undefined` (not `??`) so an explicit server `null`
+                // clears the field instead of falling back to the stale local value.
+                const prevReplyTo = current.replyToMessage;
+                const prevReactions = current.reactions;
+                Object.assign(current, message);
+                current.replyToMessage = message.replyToMessage ?? prevReplyTo;
+                current.reactions = message.reactions ?? prevReactions;
+                if (message.threadInfo !== undefined) current.threadInfo = message.threadInfo;
               } else if (current.replyToMessage?.id === messageId) {
                 current.replyToMessage.message = message.message;
                 current.replyToMessage.messageType = message.messageType;
@@ -335,6 +376,7 @@ export const {
   applyRealtimeMessage,
   confirmOptimistic,
   markOptimisticFailed,
+  updateThreadReplyCount,
 } = messagesSlice.actions;
 
 export default messagesSlice.reducer;

--- a/wetty-chat-mobile/src/store/threadsSlice.ts
+++ b/wetty-chat-mobile/src/store/threadsSlice.ts
@@ -87,6 +87,13 @@ const threadsSlice = createSlice({
       const { threadRootId, lastReplyAt, replyCount } = action.payload;
       const idx = state.items.findIndex((t) => t.threadRootMessage.id === threadRootId);
       if (idx >= 0) {
+        // When all replies are deleted, remove the thread from the list entirely
+        if (replyCount === 0) {
+          state.items.splice(idx, 1);
+          state.subscriptionByThreadId[threadRootId] = false;
+          delete state.archivedByThreadId[threadRootId];
+          return;
+        }
         const thread = state.items[idx];
         thread.replyCount = replyCount;
         thread.lastReplyAt = lastReplyAt;


### PR DESCRIPTION
 ## Summary

Fix unexpected behaviors when deleting thread messages. This cleans up all related edge cases, past regressions, and partial fixes once and for all.

## Problem

- Deleting the last reply didn't clear the thread badge on the root message.
- Deleting a root message completely hid it from the timeline, blocking access to its underlying thread.
- Users could still try to edit/delete root messages that were already deleted.
- Users weren't automatically redirected out of the thread view when both the root message and all replies were deleted.

## Changes

### Backend

- **threads.rs**: Reset `has_thread` to `false` when the last reply is removed. Remove stale `has_thread` filter from `build_thread_update_payload`.
- **messages.rs**: Allow thread replies to deleted roots that already have threads. Block creating *new* threads on deleted messages with no existing replies. Broadcast updated root message to all chat members (not just thread subscribers) when a thread reply is deleted.
- **background.rs**: Use `broadcast_thread_update_to_uids` during bulk delete to notify all members.

### Frontend

- **messages/slice.ts**: Keep deleted thread roots in timeline with `isDeleted` flag instead of removing them. Add `updateThreadReplyCount` reducer to sync reply counts from WebSocket.
- **store/index.ts**: Listen for `updateThreadFromWs` and refresh the parent chat timeline when `replyCount` drops to 0.
- **conversation.tsx**: Auto-redirect to parent chat when a thread's root message disappears from the store.
- **overlayActionPolicy.ts**: Hide edit, delete, and thread actions on deleted messages.

## Note

Related tests, code deduplication, and comment cleanup are deferred to #411. Thread deletion and message forwarding share heavily coupled logic, so it makes sense to address them together there.