### PR TITLE
fix(pwa): fix UI bugs and virtual scroll jumps

### DIFF
--- a/wetty-chat-mobile/src/components/chat/messages/ChatBubble.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/ChatBubble.tsx
@@ -96,20 +96,25 @@ export function ChatBubble(props: ChatBubbleProps) {
   const [offset, setOffset] = useState(0);
   const [animating, setAnimating] = useState(false);
 
-  // Report this bubble's live swipe offset to the SenderGroup so the floating
-  // avatar can mirror it — but only for the last message in the group. The group
-  // applies the transform directly to the avatar DOM node (no React state), so
-  // this stays 60fps even for large groups. When the context is null (search /
-  // read-only / showAllAvatars inline mode) this is a no-op.
+  // Report this bubble's live swipe offset to the SenderGroup. Every bubble
+  // reports so the group can raise its message column z-index while swiping
+  // (bubble paints OVER the avatar); the last message additionally drives the
+  // floating avatar's horizontal transform (isLastInGroup gate lives inside
+  // SenderGroup.reportSwipe). Mutates the DOM directly (no state) so swiping
+  // stays 60fps. When the context is null (search / read-only / showAllAvatars
+  // inline mode) this is a no-op.
   useEffect(() => {
-    if (!isLastInGroup || !swipeCtx) return;
-    swipeCtx.reportSwipe(offset * swipeSign, animating);
+    if (!swipeCtx) return;
+    swipeCtx.reportSwipe(offset * swipeSign, animating, !!isLastInGroup);
   }, [offset, animating, isLastInGroup, swipeCtx, swipeSign]);
 
-  // On unmount, release the avatar so it doesn't keep a stale transform.
+  // On unmount, release the avatar so it doesn't keep a stale transform. Only
+  // the last message owns the avatar transform, so only it needs this cleanup;
+  // non-last bubbles reset the column z-index via the offset effect above when
+  // their swipe ends (offset → 0).
   useEffect(() => {
     return () => {
-      if (isLastInGroup && swipeCtx) swipeCtx.reportSwipe(0, false);
+      if (isLastInGroup && swipeCtx) swipeCtx.reportSwipe(0, false, isLastInGroup);
     };
   }, [isLastInGroup, swipeCtx]);
   const startX = useRef(0);

--- a/wetty-chat-mobile/src/components/chat/messages/ChatBubbleBase.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/ChatBubbleBase.tsx
@@ -509,7 +509,7 @@ export function ChatBubbleBase({
 
   if (layout === 'bubble-only') {
     return (
-      <div className={`${styles.bubbleOnly} ${isSent ? styles.sent : styles.received}`}>
+      <div className={`${styles.bubbleOnly} ${isSent ? styles.sent : styles.received}`} data-message-row>
         <div className={styles.bubbleWrapper}>
           {bubble}
           {reactionsContent}
@@ -520,7 +520,7 @@ export function ChatBubbleBase({
 
   return (
     <>
-      <div className={`${styles.chatRow} ${isSent ? styles.sent : styles.received}`}>
+      <div className={`${styles.chatRow} ${isSent ? styles.sent : styles.received}`} data-message-row>
         <div className={styles.messageColumn}>
           <div className={styles.avatarBubbleRow}>
             {showAvatar ? (

--- a/wetty-chat-mobile/src/components/chat/messages/InviteBubble.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/InviteBubble.tsx
@@ -76,7 +76,11 @@ export function InviteBubble({
   );
 
   if (layout === 'bubble-only') {
-    return <div className={`${styles.bubbleOnly} ${isSent ? styles.sent : styles.received}`}>{bubble}</div>;
+    return (
+      <div className={`${styles.bubbleOnly} ${isSent ? styles.sent : styles.received}`} data-message-row>
+        {bubble}
+      </div>
+    );
   }
 
   return (

--- a/wetty-chat-mobile/src/components/chat/messages/SenderGroup.module.scss
+++ b/wetty-chat-mobile/src/components/chat/messages/SenderGroup.module.scss
@@ -41,15 +41,15 @@
   width: 100%;
 }
 
-// Received groups render the message column above the sticky avatar
-// (.avatarContainer z-index:2) so a left-swiping bubble paints OVER the floating
-// avatar instead of under it. The avatar stays tappable: the per-row avatarSpacer
-// (ChatBubble.module.scss) is pointer-events:none, so taps fall through to the
-// avatar behind. Sent groups omit this class, keeping the avatar on top — sent
-// swipes move the bubble away from the right-side avatar, so no overlap either way.
+// Received: the message column sits BELOW the sticky avatar (z-index 1 < 2)
+// so the avatar is directly tappable — no pointer-events passthrough needed.
+// reportSwipe raises the column to z-index 3 while the last message is swiped,
+// so the left-sliding bubble paints OVER the avatar (original swipe visual).
+// Sent groups omit this class: sent swipes move the bubble away from the
+// right-side avatar, so the two never overlap regardless of z-index.
 .messageColumnAbove {
   position: relative;
-  z-index: 3;
+  z-index: 1;
 }
 
 // Zero-height sentinel placed at the bottom of .messageColumn. An

--- a/wetty-chat-mobile/src/components/chat/messages/SenderGroup.module.scss
+++ b/wetty-chat-mobile/src/components/chat/messages/SenderGroup.module.scss
@@ -41,22 +41,10 @@
   width: 100%;
 }
 
-// Received: the message column sits BELOW the sticky avatar (z-index 1 < 2)
-// so the avatar is directly tappable — no pointer-events passthrough needed.
-// reportSwipe raises the column to z-index 3 while the last message is swiped,
-// so the left-sliding bubble paints OVER the avatar (original swipe visual).
-// Sent groups omit this class: sent swipes move the bubble away from the
-// right-side avatar, so the two never overlap regardless of z-index.
+// Received: the message column sits below the sticky avatar (z-index 1 < 2)
+// so the avatar is tappable at rest; reportSwipe raises it to z-index 3 while
+// any bubble is swiping so it paints OVER the avatar.
 .messageColumnAbove {
   position: relative;
   z-index: 1;
-}
-
-// Zero-height sentinel placed at the bottom of .messageColumn. An
-// IntersectionObserver watches it: when it intersects the viewport the group's
-// bottom is visible, so the sticky avatar is at rest (aligned with the last
-// message) and the avatar may slide with a swipe on that last message. When the
-// sentinel is out of view the group is still mid-scroll and the avatar stays put.
-.sentinel {
-  height: 0;
 }

--- a/wetty-chat-mobile/src/components/chat/messages/SenderGroup.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/SenderGroup.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState, type ReactNode } from 'react';
+import { useCallback, useLayoutEffect, useRef, useState, type ReactNode } from 'react';
 import { UserAvatar } from '@/components/UserAvatar';
 import type { User } from '@/api/messages';
 import { SenderSwipeContext } from './SenderSwipeContext';
@@ -34,15 +34,14 @@ export function SenderGroup({ useStickyAvatar, isSent, sender, onAvatarClick, ch
   const rootRef = useRef<HTMLDivElement>(null);
   const [avatarContainerBottom, setAvatarContainerBottom] = useState(0);
 
-  // The avatar follows the last message's swipe — but only when the group is at
-  // rest (avatar settled at the last message). Mutated directly on the DOM via
-  // `avatarRef` to avoid re-rendering the whole group (and its N ChatBubbles) on
-  // every touchmove frame. `avatarAtRestRef` is the gate; the sentinel's
-  // IntersectionObserver flips it (in-view = group bottom visible = at rest).
+  // The avatar follows the last message's swipe. Mutated directly on the DOM
+  // via `avatarRef` to avoid re-rendering the whole group (and its N
+  // ChatBubbles) on every touchmove frame. No rest-gate needed: only the last
+  // message can be swiped (it's in the viewport when touched), and when it is,
+  // the sticky avatar has already aligned with it — so the transform is always
+  // safe to apply.
   const avatarRef = useRef<HTMLDivElement>(null);
   const messageColumnRef = useRef<HTMLDivElement>(null);
-  const avatarAtRestRef = useRef(true);
-  const sentinelRef = useRef<HTMLDivElement>(null);
 
   useLayoutEffect(() => {
     const root = rootRef.current;
@@ -78,31 +77,6 @@ export function SenderGroup({ useStickyAvatar, isSent, sender, onAvatarClick, ch
     return () => ro.disconnect();
   }, [useStickyAvatar]);
 
-  // Track whether the group's bottom is in the viewport. When it is, the sticky
-  // avatar has settled at the last message and should slide with that message's
-  // swipe. When it isn't (long group, avatar still stuck higher), keep it static.
-  useEffect(() => {
-    const sentinel = sentinelRef.current;
-    if (!sentinel) return;
-    const io = new IntersectionObserver(
-      (entries) => {
-        const entry = entries[0];
-        if (!entry) return;
-        avatarAtRestRef.current = entry.isIntersecting;
-        // Leaving the rest state: drop any in-flight transform so the avatar
-        // snaps back to its sticky (non-swiped) position immediately.
-        if (!entry.isIntersecting && avatarRef.current) {
-          avatarRef.current.style.transform = '';
-          avatarRef.current.style.transition = '';
-        }
-      },
-      // root: null = viewport. The chat scroll surface is viewport-sized.
-      { threshold: 0 },
-    );
-    io.observe(sentinel);
-    return () => io.disconnect();
-  }, []);
-
   // Every bubble reports its live swipe; SenderGroup mutates the DOM directly
   // (no state) so swiping stays 60fps regardless of group size. Two effects:
   //  - any bubble: raise the message column z-index so it paints over the avatar
@@ -111,16 +85,14 @@ export function SenderGroup({ useStickyAvatar, isSent, sender, onAvatarClick, ch
   const reportSwipe = useCallback((transformPx: number, animating: boolean, isLast: boolean) => {
     // Raise the message column above the avatar while any bubble is swiping
     // (z 3 > 2) so it paints OVER the avatar. Drop back to CSS default (1) on
-    // release so the avatar stays directly tappable at rest. Not gated by
-    // avatarAtRestRef: even mid-scroll (avatar stuck elsewhere) the swipe
-    // visual should win, and there is no overlap to protect in that state anyway.
-    const mc = messageColumnRef.current;
-    if (mc) mc.style.zIndex = transformPx !== 0 ? '3' : '';
+    // release so the avatar stays directly tappable at rest.
+    const messageColumn = messageColumnRef.current;
+    if (messageColumn) messageColumn.style.zIndex = transformPx !== 0 ? '3' : '';
     // Only the last message's swipe drives the floating avatar transform;
     // non-last bubbles slide over the (stationary) avatar instead of dragging it.
     if (!isLast) return;
     const el = avatarRef.current;
-    if (!el || !avatarAtRestRef.current) return;
+    if (!el) return;
     el.style.transform = transformPx !== 0 ? `translateX(${transformPx}px)` : '';
     el.style.transition = animating ? SNAP_BACK_TRANSITION : '';
   }, []);
@@ -155,7 +127,6 @@ export function SenderGroup({ useStickyAvatar, isSent, sender, onAvatarClick, ch
         className={`${styles.messageColumn}${!isSent ? ` ${styles.messageColumnAbove}` : ''}`}
       >
         <SenderSwipeContext.Provider value={{ reportSwipe }}>{children}</SenderSwipeContext.Provider>
-        <div ref={sentinelRef} className={styles.sentinel} aria-hidden="true" />
       </div>
     </div>
   );

--- a/wetty-chat-mobile/src/components/chat/messages/SenderGroup.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/SenderGroup.tsx
@@ -40,6 +40,7 @@ export function SenderGroup({ useStickyAvatar, isSent, sender, onAvatarClick, ch
   // every touchmove frame. `avatarAtRestRef` is the gate; the sentinel's
   // IntersectionObserver flips it (in-view = group bottom visible = at rest).
   const avatarRef = useRef<HTMLDivElement>(null);
+  const messageColumnRef = useRef<HTMLDivElement>(null);
   const avatarAtRestRef = useRef(true);
   const sentinelRef = useRef<HTMLDivElement>(null);
 
@@ -102,9 +103,22 @@ export function SenderGroup({ useStickyAvatar, isSent, sender, onAvatarClick, ch
     return () => io.disconnect();
   }, []);
 
-  // Only the last message reports; its updates drive the avatar transform. Mutates
-  // the DOM directly (no state) so swiping stays 60fps regardless of group size.
-  const reportSwipe = useCallback((transformPx: number, animating: boolean) => {
+  // Every bubble reports its live swipe; SenderGroup mutates the DOM directly
+  // (no state) so swiping stays 60fps regardless of group size. Two effects:
+  //  - any bubble: raise the message column z-index so it paints over the avatar
+  //    while swiping, then restore it so the avatar is tappable at rest;
+  //  - only the last bubble (isLast): also drive the floating avatar transform.
+  const reportSwipe = useCallback((transformPx: number, animating: boolean, isLast: boolean) => {
+    // Raise the message column above the avatar while any bubble is swiping
+    // (z 3 > 2) so it paints OVER the avatar. Drop back to CSS default (1) on
+    // release so the avatar stays directly tappable at rest. Not gated by
+    // avatarAtRestRef: even mid-scroll (avatar stuck elsewhere) the swipe
+    // visual should win, and there is no overlap to protect in that state anyway.
+    const mc = messageColumnRef.current;
+    if (mc) mc.style.zIndex = transformPx !== 0 ? '3' : '';
+    // Only the last message's swipe drives the floating avatar transform;
+    // non-last bubbles slide over the (stationary) avatar instead of dragging it.
+    if (!isLast) return;
     const el = avatarRef.current;
     if (!el || !avatarAtRestRef.current) return;
     el.style.transform = transformPx !== 0 ? `translateX(${transformPx}px)` : '';
@@ -120,9 +134,10 @@ export function SenderGroup({ useStickyAvatar, isSent, sender, onAvatarClick, ch
 
   const senderName = sender.name ?? `User ${sender.uid}`;
   const containerClass = `${styles.avatarContainer}${isSent ? ` ${styles.sent}` : ''}`;
-  // Received: raise the message column above the sticky avatar so a left-swiping
-  // bubble slides OVER the floating avatar. Sent keeps the avatar on top (sent
-  // swipes move the bubble away from the right-side avatar, so no overlap).
+  // Received: the message column defaults below the sticky avatar (z 1 < 2) so
+  // the avatar is tappable; reportSwipe raises it to z 3 while swiping so the
+  // bubble paints OVER the avatar. Sent keeps the avatar on top (sent swipes
+  // move the bubble away from the right-side avatar, so no overlap).
 
   return (
     <div ref={rootRef} className={styles.root}>
@@ -135,7 +150,10 @@ export function SenderGroup({ useStickyAvatar, isSent, sender, onAvatarClick, ch
           onClick={() => onAvatarClick(sender)}
         />
       </div>
-      <div className={`${styles.messageColumn}${!isSent ? ` ${styles.messageColumnAbove}` : ''}`}>
+      <div
+        ref={messageColumnRef}
+        className={`${styles.messageColumn}${!isSent ? ` ${styles.messageColumnAbove}` : ''}`}
+      >
         <SenderSwipeContext.Provider value={{ reportSwipe }}>{children}</SenderSwipeContext.Provider>
         <div ref={sentinelRef} className={styles.sentinel} aria-hidden="true" />
       </div>

--- a/wetty-chat-mobile/src/components/chat/messages/SenderSwipeContext.ts
+++ b/wetty-chat-mobile/src/components/chat/messages/SenderSwipeContext.ts
@@ -1,18 +1,25 @@
 import { createContext } from 'react';
 
 /**
- * Reports the live swipe transform of the group's LAST message bubble up to the
- * SenderGroup, so the floating sticky avatar can slide horizontally together
- * with that bubble — but only when the group is at rest (avatar aligned with the
- * last message). SenderGroup applies the transform; non-last messages and groups
- * whose avatar is still stuck mid-scroll keep the avatar static.
+ * Reports the live swipe transform of any message bubble in the group up to the
+ * SenderGroup. Two effects, both driven by the bubble's signed translateX:
+ *
+ *  1. The group raises its message column z-index while any bubble is swiping
+ *     (z 3 > avatar 2) so the bubble paints OVER the sticky avatar, then drops
+ *     it back to the CSS default (1) on release so the avatar stays tappable.
+ *  2. Only the LAST message also drives the floating avatar's horizontal transform
+ *     — the avatar slides together with that bubble, but only when the group is
+ *     at rest (avatar aligned with the last message). Non-last bubbles slide over
+ *     the stationary avatar instead of dragging it.
  *
  * `transformPx` is the already-signed translateX (offset * swipeSign), so the
  * avatar mirrors the bubble exactly. `animating` mirrors the `.snapBack` flag so
- * the snap-back transition stays in sync.
+ * the snap-back transition stays in sync. `isLastInGroup` selects effect (2).
+ * When the context is null (search / read-only / showAllAvatars inline mode)
+ * ChatBubble's reporting is a no-op.
  */
 export interface SenderSwipeContextValue {
-  reportSwipe: (transformPx: number, animating: boolean) => void;
+  reportSwipe: (transformPx: number, animating: boolean, isLastInGroup: boolean) => void;
 }
 
 export const SenderSwipeContext = createContext<SenderSwipeContextValue | null>(null);

--- a/wetty-chat-mobile/src/components/chat/messages/SenderSwipeContext.ts
+++ b/wetty-chat-mobile/src/components/chat/messages/SenderSwipeContext.ts
@@ -1,22 +1,14 @@
 import { createContext } from 'react';
 
 /**
- * Reports the live swipe transform of any message bubble in the group up to the
- * SenderGroup. Two effects, both driven by the bubble's signed translateX:
+ * Lets a ChatBubble report its live swipe transform up to the enclosing
+ * SenderGroup, which applies the effect directly to the DOM (no React state)
+ * so swiping stays 60fps regardless of group size. Two effects, gated by
+ * `isLastInGroup`: any bubble raises the message column z-index so it paints
+ * over the sticky avatar; the last bubble also slides the avatar horizontally.
  *
- *  1. The group raises its message column z-index while any bubble is swiping
- *     (z 3 > avatar 2) so the bubble paints OVER the sticky avatar, then drops
- *     it back to the CSS default (1) on release so the avatar stays tappable.
- *  2. Only the LAST message also drives the floating avatar's horizontal transform
- *     — the avatar slides together with that bubble, but only when the group is
- *     at rest (avatar aligned with the last message). Non-last bubbles slide over
- *     the stationary avatar instead of dragging it.
- *
- * `transformPx` is the already-signed translateX (offset * swipeSign), so the
- * avatar mirrors the bubble exactly. `animating` mirrors the `.snapBack` flag so
- * the snap-back transition stays in sync. `isLastInGroup` selects effect (2).
  * When the context is null (search / read-only / showAllAvatars inline mode)
- * ChatBubble's reporting is a no-op.
+ * ChatBubble's reporting is a no-op. See SenderGroup.reportSwipe for details.
  */
 export interface SenderSwipeContextValue {
   reportSwipe: (transformPx: number, animating: boolean, isLastInGroup: boolean) => void;

--- a/wetty-chat-mobile/src/components/chat/messages/StickerBubble.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/StickerBubble.tsx
@@ -106,7 +106,11 @@ export function StickerBubble({
   );
 
   if (layout === 'bubble-only') {
-    return <div className={`${styles.bubbleOnly} ${isSent ? styles.sent : styles.received}`}>{bubble}</div>;
+    return (
+      <div className={`${styles.bubbleOnly} ${isSent ? styles.sent : styles.received}`} data-message-row>
+        {bubble}
+      </div>
+    );
   }
 
   return (

--- a/wetty-chat-mobile/src/components/chat/virtualScroll/ChatVirtualScroll.tsx
+++ b/wetty-chat-mobile/src/components/chat/virtualScroll/ChatVirtualScroll.tsx
@@ -226,6 +226,7 @@ export function ChatVirtualScroll({
   const [containerHeight, setContainerHeight] = useState(0);
   const [headerHeight, setHeaderHeight] = useState(0);
   const [highlightedRowKey, setHighlightedRowKey] = useState<string | null>(null);
+  const [highlightedMessageId, setHighlightedMessageId] = useState<string | null>(null);
   const [hiddenDateRowKey, setHiddenDateRowKey] = useState<string | null>(null);
   const [renderTick, setRenderTick] = useState(0);
   const triggerRender = useCallback(() => setRenderTick((value) => value + 1), []);
@@ -598,17 +599,50 @@ export function ChatVirtualScroll({
     [],
   );
 
-  const triggerJumpTargetHighlight = useCallback((key: string) => {
+  const triggerJumpTargetHighlight = useCallback((key?: string, messageId?: string) => {
     if (highlightTimerRef.current) {
       clearTimeout(highlightTimerRef.current);
     }
 
-    setHighlightedRowKey(key);
+    if (messageId) {
+      setHighlightedRowKey(null);
+      setHighlightedMessageId(messageId);
+    } else {
+      setHighlightedRowKey(key ?? null);
+      setHighlightedMessageId(null);
+    }
+
     highlightTimerRef.current = setTimeout(() => {
       setHighlightedRowKey((current) => (current === key ? null : current));
+      setHighlightedMessageId((current) => (current === messageId ? null : current));
       highlightTimerRef.current = null;
     }, JUMP_TARGET_HIGHLIGHT_MS);
   }, []);
+
+  // Highlight the specific message bubble via DOM — avoids prop threading through
+  // SenderGroup / ChatMessageRow / ChatBubble. Re-runs on every renderTick so the
+  // highlight survives virtual-scroll remounts.
+  useLayoutEffect(() => {
+    if (!highlightedMessageId) return;
+
+    const container = containerRef.current;
+    if (!container) return;
+
+    const target = container.querySelector(`[data-message-id="${highlightedMessageId}"]`);
+    if (!target) return;
+
+    const chatRow = target.closest('[class*="chatRow"]') ?? target.closest('[class*="bubbleOnly"]');
+    if (!chatRow) return;
+
+    const el = chatRow as HTMLElement;
+    el.style.transition = 'background-color 100ms ease-out';
+    el.style.backgroundColor = 'rgba(var(--ion-color-warning-rgb), 0.18)';
+
+    return () => {
+      el.style.backgroundColor = '';
+      el.style.transition = '';
+    };
+  }, [highlightedMessageId, renderTick]);
 
   const resolveMessageTarget = useCallback(
     (messageId: string) => {
@@ -1434,9 +1468,15 @@ export function ChatVirtualScroll({
           }
         }
         if (scrolled) {
-          // Skip highlight when resuming the latest message — no jump is happening.
-          if (target.index < rowKeys.length - 1) {
-            triggerJumpTargetHighlight(target.key);
+          // Skip highlight only when resuming to the very latest message (all read →
+          // no jump). Compare by messageId, not row index: with sticky-avatar grouping
+          // the last group row holds multiple messages, so a row-index check would
+          // wrongly suppress the unread-divider flash whenever the last-read message
+          // shares the final group with later unread messages.
+          const lastRow = rows[rows.length - 1];
+          const latestMessageId = lastRow?.type === 'group' ? lastRow.lastMessageId : null;
+          if (intent.scrollToMessageId.messageId !== latestMessageId) {
+            triggerJumpTargetHighlight(target.key, intent.scrollToMessageId.messageId);
           }
         }
       } else {
@@ -2257,7 +2297,7 @@ export function ChatVirtualScroll({
           if (scrolled) {
             // Skip highlight when resuming the latest message — no jump is happening.
             if (target.index < rowKeys.length - 1) {
-              triggerJumpTargetHighlight(target.key);
+              triggerJumpTargetHighlight(target.key, messageId);
             }
             pendingScrollMessageIdRef.current = null;
           }

--- a/wetty-chat-mobile/src/components/chat/virtualScroll/ChatVirtualScroll.tsx
+++ b/wetty-chat-mobile/src/components/chat/virtualScroll/ChatVirtualScroll.tsx
@@ -1200,7 +1200,6 @@ export function ChatVirtualScroll({
           nextHeight: height,
           delta: height - previousHeight,
           scrollTop: container.scrollTop,
-          rowOffsetTop: rowNode.offsetTop,
           strategy: 'bottom-lock',
         });
         scrollToBottomInternal();

--- a/wetty-chat-mobile/src/components/chat/virtualScroll/ChatVirtualScroll.tsx
+++ b/wetty-chat-mobile/src/components/chat/virtualScroll/ChatVirtualScroll.tsx
@@ -622,19 +622,24 @@ export function ChatVirtualScroll({
   // Highlight the specific message bubble via DOM — avoids prop threading through
   // SenderGroup / ChatMessageRow / ChatBubble. Re-runs on every renderTick so the
   // highlight survives virtual-scroll remounts.
+  //
+  // Coupling note: this reaches into ChatBubble's DOM by querying the stable
+  // `data-message-row` attribute (set by ChatBubbleBase / StickerBubble /
+  // InviteBubble). If those components stop emitting the attribute the highlight
+  // will silently no-op — there is no compile-time link between the two.
   useLayoutEffect(() => {
     if (!highlightedMessageId) return;
 
     const container = containerRef.current;
     if (!container) return;
 
-    const target = container.querySelector(`[data-message-id="${highlightedMessageId}"]`);
+    const target = container.querySelector(`[data-message-id="${CSS.escape(highlightedMessageId)}"]`);
     if (!target) return;
 
-    const chatRow = target.closest('[class*="chatRow"]') ?? target.closest('[class*="bubbleOnly"]');
+    const chatRow = target.closest('[data-message-row]');
     if (!chatRow) return;
-
     const el = chatRow as HTMLElement;
+
     el.style.transition = 'background-color 100ms ease-out';
     el.style.backgroundColor = 'rgba(var(--ion-color-warning-rgb), 0.18)';
 

--- a/wetty-chat-mobile/src/components/chat/virtualScroll/ChatVirtualScroll.tsx
+++ b/wetty-chat-mobile/src/components/chat/virtualScroll/ChatVirtualScroll.tsx
@@ -167,6 +167,12 @@ export function ChatVirtualScroll({
   const pendingPrependRestoreRef = useRef<{ key: string; offsetTop: number } | null>(null);
   const pendingDeleteRestoreRef = useRef<{ key: string; offsetTop: number } | null>(null);
   const pendingPrependCompensationRef = useRef<number | null>(null);
+  // Tracks the last message id seen on the previous layout pass. With sticky-avatar
+  // grouping, a new message from the same sender is merged into the existing last
+  // group row, so the row key array is unchanged and classifyKeyMutation returns
+  // 'none'. Comparing the actual last message id detects this "group grew" case so
+  // the append-bottom-lock auto-scroll still fires.
+  const lastKnownLastMessageIdRef = useRef<string | null>(null);
   const pendingLayoutAnchorRestoreRef = useRef<{
     source: string;
     key: string;
@@ -1413,6 +1419,25 @@ export function ChatVirtualScroll({
     const mutation = classifyKeyMutation(prevKeysRef.current, rowKeys);
     const intent = layoutIntentRef.current;
 
+    // Sticky-avatar grouping merges same-sender messages into one group row, so a
+    // new message that joins the last group leaves rowKeys unchanged and
+    // classifyKeyMutation reports 'none'. Detect that case by comparing the last
+    // message id so the append-bottom-lock auto-scroll still fires.
+    let treatAsAppend = mutation === 'append';
+    if (mutation === 'none') {
+      let currentLastMessageId: string | null = null;
+      for (let i = rows.length - 1; i >= 0; i--) {
+        const row = rows[i];
+        if (row.type === 'group') {
+          currentLastMessageId = row.lastMessageId;
+          break;
+        }
+      }
+      if (currentLastMessageId != null && currentLastMessageId !== lastKnownLastMessageIdRef.current) {
+        treatAsAppend = true;
+      }
+    }
+
     if (intent?.preserveHeightDelta && intent.preserveHeightDelta !== 0) {
       const nextScrollTop = roundScrollValue(container.scrollTop + intent.preserveHeightDelta);
       if (hasMeaningfulScrollDelta(container.scrollTop, nextScrollTop)) {
@@ -1642,7 +1667,7 @@ export function ChatVirtualScroll({
       setPhaseState(containerHeight > 0 ? 'BOOTSTRAP' : 'WAITING_VIEWPORT');
       triggerRender();
     } else if (
-      mutation === 'append' &&
+      treatAsAppend &&
       (isAtBottomRef.current || pendingScrollToBottomRef.current) &&
       !isPageHidden() && // skip auto-scroll while backgrounded
       !intent?.scrollToKey
@@ -1660,7 +1685,7 @@ export function ChatVirtualScroll({
         pendingScrollToBottomSourceRef.current = 'append-detected';
       }
       ensureBottomMeasured();
-    } else if (mutation === 'append') {
+    } else if (treatAsAppend) {
       logVirtualScroll('append-preserve-natural-position', {
         logicalAtBottom: isAtBottomRef.current,
         visualBottomDistance: container.scrollHeight - (container.scrollTop + container.clientHeight),
@@ -1671,6 +1696,19 @@ export function ChatVirtualScroll({
     updateLastFullyVisibleMessage();
     layoutIntentRef.current = null;
     prevKeysRef.current = rowKeys;
+    // Track the last message id so the next render can detect a same-sender
+    // message merging into the final group (mutation 'none' but content grew).
+    {
+      let lastId: string | null = null;
+      for (let i = rows.length - 1; i >= 0; i--) {
+        const row = rows[i];
+        if (row.type === 'group') {
+          lastId = row.lastMessageId;
+          break;
+        }
+      }
+      lastKnownLastMessageIdRef.current = lastId;
+    }
   }, [
     rowKeys,
     rowKeys.length,

--- a/wetty-chat-mobile/src/components/chat/virtualScroll/layoutMath.test.ts
+++ b/wetty-chat-mobile/src/components/chat/virtualScroll/layoutMath.test.ts
@@ -14,6 +14,11 @@ describe('virtual scroll layout math', () => {
     expect(classifyKeyMutation(['grp:3', 'grp:4'], ['grp:1', 'grp:2', 'grp:3', 'grp:4'])).toBe('prepend');
     expect(classifyKeyMutation(['grp:1', 'grp:2'], ['grp:1', 'grp:2', 'date:b', 'grp:3'])).toBe('append');
     expect(classifyKeyMutation(['grp:1', 'grp:3'], ['grp:1', 'grp:2', 'grp:3'])).toBe('reset');
+    // Prepend-merge: older same-sender messages merge into the old first
+    // group, changing its key (derived from the first message id). Must still
+    // classify as prepend, not reset, so the prepend compensation keeps the
+    // scroll position instead of re-bootstrapping to the latest message.
+    expect(classifyKeyMutation(['grp:1', 'grp:2', 'grp:3'], ['grp:0', 'grp:1m', 'grp:2', 'grp:3'])).toBe('prepend');
   });
 
   it('normalizes, unions, and caps mounted ranges', () => {

--- a/wetty-chat-mobile/src/components/chat/virtualScroll/layoutMath.ts
+++ b/wetty-chat-mobile/src/components/chat/virtualScroll/layoutMath.ts
@@ -10,10 +10,13 @@ function isPrefix(prefix: string[], full: string[]): boolean {
   return prefix.every((value, index) => full[index] === value);
 }
 
-function isSuffix(suffix: string[], full: string[]): boolean {
-  if (suffix.length > full.length) return false;
-  const offset = full.length - suffix.length;
-  return suffix.every((value, index) => full[offset + index] === value);
+function commonSuffixLength(a: string[], b: string[]): number {
+  const max = Math.min(a.length, b.length);
+  let len = 0;
+  while (len < max && a[a.length - 1 - len] === b[b.length - 1 - len]) {
+    len += 1;
+  }
+  return len;
 }
 
 function isSubsequence(sub: string[], full: string[]): boolean {
@@ -32,7 +35,22 @@ export function classifyKeyMutation(prev: string[], next: string[]): MutationTyp
   if (prevMsgs.length === 0 || nextMsgs.length === 0) return 'reset';
   if (nextMsgs.length < prevMsgs.length && isSubsequence(nextMsgs, prevMsgs)) return 'delete';
   if (nextMsgs.length < prevMsgs.length) return 'reset';
-  if (isSuffix(prevMsgs, nextMsgs)) return 'prepend';
+  // Prepend: older messages added at the front. Normally prev is an exact suffix
+  // of next. But when prepended messages merge into the old first group (same
+  // sender + same date), that group's key changes (it derives from the first
+  // message id), so prev is no longer an exact suffix. Detect this by allowing
+  // only the leading group to differ — and only when its old key truly
+  // disappeared from next (merged away, not merely repositioned by a middle
+  // insert). Otherwise a middle insert would be misread as a prepend.
+  const commonSuffix = commonSuffixLength(prevMsgs, nextMsgs);
+  if (nextMsgs.length > prevMsgs.length) {
+    if (commonSuffix >= prevMsgs.length) {
+      return 'prepend';
+    }
+    if (prevMsgs.length >= 2 && commonSuffix === prevMsgs.length - 1 && !nextMsgs.includes(prevMsgs[0])) {
+      return 'prepend';
+    }
+  }
   if (isPrefix(prevMsgs, nextMsgs)) return 'append';
   return 'reset';
 }


### PR DESCRIPTION
Cleaning up a few odds and ends, mostly regressions from c887109 (sticky avatar). This fixes the unclickable avatars, swipe-to-reply styling, incorrect flashing of the last unread message, and random jumps in the virtual list.

Just a heads up on the virtual scrolling: 
it's still a bit clunky. I'm honestly not sure if it was already like this before c887109. 
At least, it's usable based on my local tests, so I'm putting this PR up for now.
I might open another PR later on if I find a better solution.