### PR TITLE
style(pwa): Streamline DM styling in chat list and message bubbles

### DIFF
--- a/wetty-chat-mobile/src/components/OverlayAvatar.module.scss
+++ b/wetty-chat-mobile/src/components/OverlayAvatar.module.scss
@@ -7,6 +7,20 @@
   position: absolute;
   top: -2px;
   right: -2px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   border-radius: 50%;
   box-shadow: 0 0 0 2px var(--avatar-overlay-ring-color, var(--ion-background-color, #fff));
+}
+
+.iconBadge {
+  background: var(--ion-color-primary);
+  color: var(--ion-color-primary-contrast);
+}
+
+/* Glyph fills 2/3 of the badge circle. */
+.secondaryIcon {
+  width: 66.6667%;
+  height: 66.6667%;
 }

--- a/wetty-chat-mobile/src/components/OverlayAvatar.tsx
+++ b/wetty-chat-mobile/src/components/OverlayAvatar.tsx
@@ -1,3 +1,4 @@
+import { IonIcon } from '@ionic/react';
 import { UserAvatar } from '@/components/UserAvatar';
 import styles from './OverlayAvatar.module.scss';
 
@@ -6,6 +7,8 @@ interface OverlayAvatarProps {
   primaryAvatarUrl?: string | null;
   secondaryName?: string | null;
   secondaryAvatarUrl?: string | null;
+  /** When set, the secondary corner renders this icon badge instead of a second avatar. */
+  secondaryIcon?: string;
   size?: number;
   secondarySize?: number;
   className?: string;
@@ -16,6 +19,7 @@ export function OverlayAvatar({
   primaryAvatarUrl,
   secondaryName,
   secondaryAvatarUrl,
+  secondaryIcon,
   size = 40,
   secondarySize = Math.max(16, Math.round(size * 0.55)),
   className,
@@ -25,7 +29,14 @@ export function OverlayAvatar({
   return (
     <div className={classes} style={{ width: size, height: size }}>
       <UserAvatar name={primaryName} avatarUrl={primaryAvatarUrl} size={size} />
-      {secondaryName ? (
+      {secondaryIcon ? (
+        <div
+          className={`${styles.secondary} ${styles.iconBadge}`}
+          style={{ width: secondarySize, height: secondarySize }}
+        >
+          <IonIcon icon={secondaryIcon} className={styles.secondaryIcon} />
+        </div>
+      ) : secondaryName ? (
         <div className={styles.secondary}>
           <UserAvatar name={secondaryName} avatarUrl={secondaryAvatarUrl} size={secondarySize} />
         </div>

--- a/wetty-chat-mobile/src/components/chat/compose/ComposeContextBanner.tsx
+++ b/wetty-chat-mobile/src/components/chat/compose/ComposeContextBanner.tsx
@@ -3,6 +3,8 @@ import { t } from '@lingui/core/macro';
 import { closeCircle } from 'ionicons/icons';
 import { useSelector } from 'react-redux';
 import { selectEffectiveLocale } from '@/store/settingsSlice';
+import { selectChatMeta } from '@/store/chatsSlice';
+import type { RootState } from '@/store';
 import { useChatContext } from '@/components/chat/messages/ChatContext';
 import { formatMessagePreview, getNotificationPreviewLabels } from '@/utils/messagePreview';
 import type { EditingMessage, ReplyTo } from './types';
@@ -17,6 +19,9 @@ interface ComposeContextBannerProps {
 
 export function ComposeContextBanner({ editing, replyTo, onCancelEdit, onCancelReply }: ComposeContextBannerProps) {
   const locale = useSelector(selectEffectiveLocale);
+  const chatId = useChatContext()?.chatId;
+  // DM reply banners show only the quoted content — the conversation is 1:1.
+  const isDm = useSelector((state: RootState) => selectChatMeta(state, String(chatId))?.kind === 'dm');
 
   const ctx = useChatContext();
 
@@ -45,7 +50,7 @@ export function ComposeContextBanner({ editing, replyTo, onCancelEdit, onCancelR
   return (
     <div className={styles.replyPreview}>
       <div className={`${styles.replyText} ${styles.replyPreviewTappable}`} onClick={handleJumpToReply}>
-        <span className={styles.replyUsername}>{t`Replying to ${replyTo.username}`}</span>
+        {!isDm && <span className={styles.replyUsername}>{t`Replying to ${replyTo.username}`}</span>}
         <span className={styles.replySnippet}>
           {formatMessagePreview(replyTo, getNotificationPreviewLabels(locale))}
         </span>

--- a/wetty-chat-mobile/src/components/chat/lists/ChatList.tsx
+++ b/wetty-chat-mobile/src/components/chat/lists/ChatList.tsx
@@ -112,11 +112,17 @@ function isChatMuted(chat: ChatListEntry): boolean {
   return new Date(chat.mutedUntil) > new Date();
 }
 
-function getMessagePreview(message: MessagePreview | null, locale: string): ReactNode {
+function getMessagePreview(message: MessagePreview | null, locale: string, showSender: boolean): ReactNode {
   if (!message) return t`No messages yet`;
 
-  const senderName = message.sender?.name || 'User';
   const previewText = formatMessagePreview(message, getNotificationPreviewLabels(locale));
+
+  // DM rows omit the sender name — the row title already names the peer.
+  if (!showSender) {
+    return previewText || t`New message`;
+  }
+
+  const senderName = message.sender?.name || 'User';
 
   return (
     <>
@@ -588,7 +594,7 @@ export function ChatList({
                 {truncatePreview(drafts[chat.id].text)}
               </>
             ) : (
-              getMessagePreview(chat.lastMessage, locale)
+              getMessagePreview(chat.lastMessage, locale, chat.kind !== 'dm')
             )}
           </p>
         </IonLabel>

--- a/wetty-chat-mobile/src/components/chat/lists/ThreadListRow.tsx
+++ b/wetty-chat-mobile/src/components/chat/lists/ThreadListRow.tsx
@@ -1,10 +1,13 @@
 import { type ReactNode, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { IonBadge, IonIcon, IonItem, IonItemOption, IonItemOptions, IonItemSliding, IonLabel } from '@ionic/react';
+import { chatbubbles } from 'ionicons/icons';
 import { t } from '@lingui/core/macro';
 import { toMessagePreview, type MessagePreview } from '@/api/messages';
 import type { StoredThreadListItem } from '@/api/threads';
 import { OverlayAvatar } from '@/components/OverlayAvatar';
+import { selectCurrentUser } from '@/store/userSlice';
+import { selectChatMeta } from '@/store/chatsSlice';
 import type { RootState } from '@/store/index';
 import { selectLatestThreadReplyMessage } from '@/store/messages/selectors';
 import { formatMessagePreview, getNotificationPreviewLabels, truncatePreview } from '@/utils/messagePreview';
@@ -53,6 +56,9 @@ interface ThreadListRowProps {
 }
 
 export function ThreadListRow({ thread, locale, isActive, draftText, onSelect, endAction }: ThreadListRowProps) {
+  const currentUid = useSelector(selectCurrentUser).uid;
+  const chatMeta = useSelector((state: RootState) => selectChatMeta(state, thread.chatId));
+  const isDm = chatMeta?.kind === 'dm';
   const rootMsg = thread.threadRootMessage;
   const rootPreview = formatMessagePreview(rootMsg, getNotificationPreviewLabels(locale));
 
@@ -67,7 +73,15 @@ export function ThreadListRow({ thread, locale, isActive, draftText, onSelect, e
     return thread.cachedLastReply;
   }, [liveMessage, thread.cachedLastReply]);
 
+  // DM threads omit sender names in previews — the row's avatar/title already
+  // identify the conversation, and the participants are just the two parties.
   const lastReplyPreview = lastReply ? formatReplyPreview(lastReply, locale) : null;
+
+  // DM thread avatar: the peer as the primary avatar, with a message-bubble
+  // icon badge instead of the thread-starter avatar used for group threads.
+  const peer = isDm ? (chatMeta?.peer ?? thread.participants.find((p) => p.uid !== currentUid) ?? null) : null;
+  const peerAvatarUrl = peer?.avatarUrl ?? thread.chatAvatar ?? null;
+  const peerName = (peer ? ('username' in peer ? peer.username : peer?.name) : null) ?? thread.chatName ?? 'User';
 
   const content = (
     <IonItem
@@ -78,17 +92,26 @@ export function ThreadListRow({ thread, locale, isActive, draftText, onSelect, e
     >
       {/* Rows 2-4: avatar + content */}
       <span slot="start">
-        <OverlayAvatar
-          primaryName={thread.chatName}
-          primaryAvatarUrl={thread.chatAvatar}
-          secondaryName={rootMsg.sender.name ?? null}
-          secondaryAvatarUrl={rootMsg.sender.avatarUrl ?? null}
-          size={48}
-        />
+        {isDm ? (
+          <OverlayAvatar
+            primaryName={peerName}
+            primaryAvatarUrl={peerAvatarUrl}
+            secondaryIcon={chatbubbles}
+            size={48}
+          />
+        ) : (
+          <OverlayAvatar
+            primaryName={thread.chatName}
+            primaryAvatarUrl={thread.chatAvatar}
+            secondaryName={rootMsg.sender.name ?? null}
+            secondaryAvatarUrl={rootMsg.sender.avatarUrl ?? null}
+            size={48}
+          />
+        )}
       </span>
       <IonLabel className={styles.bodyContent}>
         {/* Row 2: replied to */}
-        <div className={styles.repliedTo}>{rootPreview || rootMsg.sender.name}</div>
+        <div className={styles.repliedTo}>{rootPreview || (isDm ? null : rootMsg.sender.name)}</div>
         {/* Row 3: latest reply or draft */}
         {draftText !== undefined ? (
           <p className={styles.latestReply}>
@@ -99,7 +122,8 @@ export function ThreadListRow({ thread, locale, isActive, draftText, onSelect, e
           lastReply &&
           lastReplyPreview && (
             <p className={styles.latestReply}>
-              <span className={styles.latestReplySender}>{lastReply.sender.name ?? 'User'}:</span> {lastReplyPreview}
+              {!isDm && <span className={styles.latestReplySender}>{lastReply.sender.name ?? 'User'}:</span>}{' '}
+              {lastReplyPreview}
             </p>
           )
         )}

--- a/wetty-chat-mobile/src/components/chat/messages/ChatMessageRow.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/ChatMessageRow.tsx
@@ -32,11 +32,14 @@ interface ChatMessageRowProps extends ChatMessageHandlers {
   row: ChatRow;
   currentUserId: number | string | null;
   threadId?: string;
+  /** DMs omit sender names/groups/genders from bubbles and reply quotes. */
+  isDm?: boolean;
 }
 export function ChatMessageRow({
   row,
   currentUserId,
   threadId,
+  isDm,
   onReply,
   onJumpToReply,
   onLongPress,
@@ -75,6 +78,7 @@ export function ChatMessageRow({
           useStickyAvatar={useStickyAvatar}
           showName={showName}
           threadId={threadId}
+          isDm={isDm}
           currentUserId={currentUserId}
           onReply={onReply}
           onJumpToReply={onJumpToReply}
@@ -98,6 +102,7 @@ interface MessageBubbleProps extends ChatMessageHandlers {
   isLastInGroup: boolean;
   showName: boolean;
   threadId?: string;
+  isDm?: boolean;
   currentUserId: number | string | null;
 }
 
@@ -109,6 +114,7 @@ function MessageBubble({
   isLastInGroup,
   showName,
   threadId,
+  isDm,
   currentUserId,
   onReply,
   onJumpToReply,
@@ -153,12 +159,14 @@ function MessageBubble({
     isConfirmed: !msg.id.startsWith('cg_'),
     uploadProgress,
     bubbleProps: { 'data-message-id': msg.id, 'data-bubble-row': '' } as BubblePropsOverride,
-    replyTo: replyToMessage
-      ? {
-          senderName: replyToMessage.sender.name ?? `User ${replyToMessage.sender.uid}`,
-          preview: replyToMessage,
-        }
-      : undefined,
+    replyTo:
+      replyToMessage && !replyToMessage.isDeleted
+        ? {
+            // DMs keep the quote but drop the sender name (empty string → no name row).
+            senderName: isDm ? '' : (replyToMessage.sender.name ?? `User ${replyToMessage.sender.uid}`),
+            preview: replyToMessage,
+          }
+        : undefined,
   } as const;
 
   if (isInviteMessage(msg)) {

--- a/wetty-chat-mobile/src/components/chat/messages/ReplyPreview.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/ReplyPreview.tsx
@@ -20,7 +20,9 @@ interface ReplyPreviewProps {
 export function ReplyPreview({ replyTo, isSent, interactive, onReplyTap }: ReplyPreviewProps) {
   const locale = useSelector(selectEffectiveLocale);
   const isDarkMode = useIsDarkMode();
-  const color = isSent ? undefined : colorForUser(replyTo.senderName, isDarkMode);
+  // When the sender name is withheld (DMs), the preview is a plain uncolored strip.
+  const hasName = replyTo.senderName.trim() !== '';
+  const color = !hasName || isSent ? undefined : colorForUser(replyTo.senderName, isDarkMode);
 
   return (
     <div
@@ -35,9 +37,11 @@ export function ReplyPreview({ replyTo, isSent, interactive, onReplyTap }: Reply
           : undefined
       }
     >
-      <div className={styles.replyPreviewName} style={color ? { color } : undefined}>
-        {replyTo.senderName}
-      </div>
+      {hasName && (
+        <div className={styles.replyPreviewName} style={color ? { color } : undefined}>
+          {replyTo.senderName}
+        </div>
+      )}
       <div className={styles.replyPreviewText}>
         {formatMessagePreview(replyTo.preview, getNotificationPreviewLabels(locale))}
       </div>

--- a/wetty-chat-mobile/src/components/chat/virtualScroll/useChatRows.ts
+++ b/wetty-chat-mobile/src/components/chat/virtualScroll/useChatRows.ts
@@ -23,6 +23,7 @@ export function useChatRows(
   messages: MessageResponse[],
   formatDateSeparator: (iso: string) => string,
   showAllAvatars: boolean,
+  showSenderNames = true,
 ): ChatRow[] {
   return useMemo(() => {
     const rows: ChatRow[] = [];
@@ -83,7 +84,9 @@ export function useChatRows(
         j += 1;
       }
 
-      const showName = msg.sender.uid !== prevSenderUid || hasDateSeparator;
+      // DMs never show sender names/groups/genders on bubbles; groups show them
+      // when the sender changes or a date separator intervenes.
+      const showName = showSenderNames && (msg.sender.uid !== prevSenderUid || hasDateSeparator);
       // When showAllAvatars is on, every message renders its own inline avatar
       // (current behavior), so the group-level sticky avatar is not used.
       const useStickyAvatar = !showAllAvatars;
@@ -104,5 +107,5 @@ export function useChatRows(
     }
 
     return rows;
-  }, [messages, formatDateSeparator, showAllAvatars]);
+  }, [messages, formatDateSeparator, showAllAvatars, showSenderNames]);
 }

--- a/wetty-chat-mobile/src/pages/conversation/ConversationOverlayHost.tsx
+++ b/wetty-chat-mobile/src/pages/conversation/ConversationOverlayHost.tsx
@@ -1,10 +1,13 @@
 import { t } from '@lingui/core/macro';
+import { useSelector } from 'react-redux';
 import { mentionToUser, type MessageResponse, type User } from '@/api/messages';
 import { MessageOverlay, type MessageOverlayAction } from '@/components/chat/messages/MessageOverlay';
 import { UserProfileModal } from '@/components/chat/profiles/UserProfileModal';
 import { ReactionDetailsModal } from '@/components/chat/reactions/ReactionDetailsModal';
 import { StickerPreviewModal } from '@/components/chat/compose/StickerPreviewModal';
 import { PinListModal } from '@/components/chat/pins/PinListModal';
+import { selectChatMeta } from '@/store/chatsSlice';
+import type { RootState } from '@/store';
 
 interface OverlayMessageState {
   message: MessageResponse;
@@ -59,6 +62,7 @@ export function ConversationOverlayHost({
   onCloseOverlay,
 }: ConversationOverlayHostProps) {
   const msg = overlayMessage?.message;
+  const isDm = useSelector((state: RootState) => selectChatMeta(state, chatId)?.kind === 'dm');
 
   return (
     <>
@@ -84,17 +88,22 @@ export function ConversationOverlayHost({
             const sharedOverlayProps = {
               senderName: msg.sender.name ?? `User ${msg.sender.uid}`,
               isSent: msg.sender.uid === currentUserId,
+              // The overlay preview always identifies the sender, even in DMs.
               showName: true,
+              replyTo:
+                msg.replyToMessage && !msg.replyToMessage.isDeleted
+                  ? {
+                      // DMs keep the quote but drop the sender name.
+                      senderName: isDm
+                        ? ''
+                        : (msg.replyToMessage.sender.name ?? `User ${msg.replyToMessage.sender.uid}`),
+                      preview: msg.replyToMessage,
+                    }
+                  : undefined,
               timestamp: msg.createdAt,
               edited: msg.isEdited,
               isConfirmed: !msg.id.startsWith('cg_'),
               messageId: msg.id,
-              replyTo: msg.replyToMessage
-                ? {
-                    senderName: msg.replyToMessage.sender.name ?? `User ${msg.replyToMessage.sender.uid}`,
-                    preview: msg.replyToMessage,
-                  }
-                : undefined,
               sourceRect: overlayMessage.sourceRect,
               interactionPos: overlayMessage.interactionPos,
               actions: overlayActions,

--- a/wetty-chat-mobile/src/pages/conversation/conversation.tsx
+++ b/wetty-chat-mobile/src/pages/conversation/conversation.tsx
@@ -155,6 +155,7 @@ function ConversationPane({ chatId, threadId, backAction }: ConversationPaneProp
     chatId,
     storeChatId,
     threadId,
+    isDm,
     initialResumeMessageId,
     lastReadMessageId,
     scrollToBottomUnreadCount: unreadCount,
@@ -460,6 +461,7 @@ function ConversationPane({ chatId, threadId, backAction }: ConversationPaneProp
           row={row}
           currentUserId={currentUser.uid}
           threadId={threadId}
+          isDm={isDm}
           onReply={setReplyingTo}
           onJumpToReply={jumpToMessage}
           onLongPress={onClickChatItem}
@@ -470,7 +472,7 @@ function ConversationPane({ chatId, threadId, backAction }: ConversationPaneProp
         />
       );
     },
-    [currentUser.uid, threadId, chatId, history, jumpToMessage, onClickChatItem, handleReactionToggle],
+    [currentUser.uid, threadId, isDm, chatId, history, jumpToMessage, onClickChatItem, handleReactionToggle],
   );
 
   const chatCtx = useMemo(() => ({ chatId, threadId, jumpToMessage }), [chatId, threadId, jumpToMessage]);

--- a/wetty-chat-mobile/src/pages/conversation/hooks/useChatMetadata.ts
+++ b/wetty-chat-mobile/src/pages/conversation/hooks/useChatMetadata.ts
@@ -71,8 +71,12 @@ export function useChatMetadata({ chatId, threadId }: UseChatMetadataArgs): UseC
   const metaLoading = !metaLoaded;
 
   useEffect(() => {
-    if (threadId || metaLoaded) return;
+    if (metaLoaded) return;
 
+    // Threads fetch too: deep links land directly on a thread without the chat
+    // list ever having populated `kind`/`peer`, and DM styling (bubbles, lists)
+    // depends on them. GET /group/:id is idempotent, so the extra fetch on
+    // thread views is safe.
     getGroupInfo(chatId)
       .then((res) => {
         const { id, mutedUntil, ...groupMeta } = res.data;
@@ -81,7 +85,7 @@ export function useChatMetadata({ chatId, threadId }: UseChatMetadataArgs): UseC
         dispatch(setChatMutedUntil({ chatId, mutedUntil: mutedUntil ?? null }));
       })
       .catch(() => {});
-  }, [chatId, dispatch, metaLoaded, threadId]);
+  }, [chatId, dispatch, metaLoaded]);
 
   useEffect(() => {
     if (threadId) return;

--- a/wetty-chat-mobile/src/pages/conversation/hooks/useConversationTimeline.ts
+++ b/wetty-chat-mobile/src/pages/conversation/hooks/useConversationTimeline.ts
@@ -35,6 +35,8 @@ interface UseConversationTimelineArgs {
   chatId: string;
   storeChatId: string;
   threadId?: string;
+  /** DMs hide sender names/groups/genders on bubbles. */
+  isDm?: boolean;
   initialResumeMessageId: string | null;
   lastReadMessageId: string | null;
   scrollToBottomUnreadCount: number;
@@ -47,6 +49,7 @@ export function useConversationTimeline({
   chatId,
   storeChatId,
   threadId,
+  isDm = false,
   initialResumeMessageId,
   lastReadMessageId,
   scrollToBottomUnreadCount,
@@ -114,7 +117,7 @@ export function useConversationTimeline({
 
   const messageLookup = useMemo(() => new Map(messages.map((message) => [message.id, message])), [messages]);
   const showAllAvatars = useSelector(selectShowAllAvatars);
-  const chatRows = useChatRows(messages, formatDateSeparator, showAllAvatars);
+  const chatRows = useChatRows(messages, formatDateSeparator, showAllAvatars, !isDm);
 
   useEffect(() => {
     if (messages.length > 0 || pendingLiveCount === 0) {


### PR DESCRIPTION
- Hide sender names in DM chat/thread list previews
- Omit sender name, group tag, and gender icon on DM message bubbles; reply quotes keep the quoted content but drop the sender name
- Show DM threads with the peer's avatar plus a message-bubble icon badge