### PR TITLE
feat(backend,pwa): DM pinning & hardening

### DIFF
--- a/backend/src/handlers/chats/messages.rs
+++ b/backend/src/handlers/chats/messages.rs
@@ -37,6 +37,7 @@ use crate::services::messages::{
     attach_metadata, authorize_message_send, extract_mention_uids, parse_attachment_ids,
     send_prepared_message, validate_message, PreparedMessageSend, SendMessageOutcome,
 };
+use crate::services::social;
 #[derive(serde::Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ListMessagesQuery {
@@ -829,6 +830,7 @@ async fn patch_message(
     let conn = &mut *conn;
 
     check_membership(conn, chat_id, uid)?;
+    social::require_chat_writable(conn, chat_id, uid)?;
 
     let attachment_ids = parse_attachment_ids(&body.attachment_ids)?;
     let now = Utc::now();
@@ -963,6 +965,7 @@ async fn delete_message(
     let conn = &mut *conn;
 
     check_membership(conn, chat_id, uid)?;
+    social::require_chat_writable(conn, chat_id, uid)?;
 
     // Verify message exists and belongs to the user
     let message: Message = messages::table

--- a/backend/src/handlers/chats/reactions.rs
+++ b/backend/src/handlers/chats/reactions.rs
@@ -24,6 +24,7 @@ use crate::{
 };
 
 use crate::services::messages::load_usernames_by_uids;
+use crate::services::social;
 
 fn validate_emoji(input: &str) -> Result<String, AppError> {
     if input.is_empty() {
@@ -225,6 +226,7 @@ async fn put_reaction(
     let conn = &mut *conn;
     let emoji = validate_emoji(&emoji)?;
     check_membership(conn, chat_id, uid)?;
+    social::require_chat_writable(conn, chat_id, uid)?;
 
     // Verify message exists and belongs to this chat
     let _message: Message = messages::table
@@ -280,6 +282,7 @@ async fn delete_reaction(
     let conn = &mut *conn;
     let emoji = validate_emoji(&emoji)?;
     check_membership(conn, chat_id, uid)?;
+    social::require_chat_writable(conn, chat_id, uid)?;
 
     // Verify message exists and is not deleted (no reaction removal on deleted messages)
     let _message: Message = messages::table

--- a/backend/src/handlers/members.rs
+++ b/backend/src/handlers/members.rs
@@ -227,6 +227,17 @@ async fn post_add_member(
     // Check if requester is admin
     require_admin_role(conn, chat_id, uid)?;
 
+    // DMs are strictly 1:1 — even a corrupted admin role must not grow them.
+    let kind: GroupKind = groups::table
+        .find(chat_id)
+        .select(groups::kind)
+        .first(conn)?;
+    if kind == GroupKind::Dm {
+        return Err(AppError::BadRequest(
+            "DM chats cannot have additional members",
+        ));
+    }
+
     let profiles = lookup_user_profiles(conn, &[body.uid])?;
     let profile = profiles.get(&body.uid);
 
@@ -492,6 +503,16 @@ async fn patch_member(
 
     // Check if requester is admin
     require_admin_role(conn, chat_id, requester_uid)?;
+
+    // Preserve the "DM members are plain members" invariant that the
+    // membership endpoints rely on.
+    let kind: GroupKind = groups::table
+        .find(chat_id)
+        .select(groups::kind)
+        .first(conn)?;
+    if kind == GroupKind::Dm {
+        return Err(AppError::BadRequest("Roles cannot be changed in DM chats"));
+    }
 
     // Prevent self-demotion
     if requester_uid == target_uid {

--- a/backend/src/handlers/pins.rs
+++ b/backend/src/handlers/pins.rs
@@ -19,8 +19,8 @@ use crate::dto::{
 use crate::errors::AppError;
 use crate::extractors::DbConn;
 use crate::handlers::members::{check_membership, require_admin_role};
-use crate::models::{Message, MessageType, NewPinnedMessage, PinnedMessage};
-use crate::schema::{group_membership, messages, pinned_messages};
+use crate::models::{GroupKind, Message, MessageType, NewPinnedMessage, PinnedMessage};
+use crate::schema::{group_membership, groups, messages, pinned_messages};
 use crate::services::messages::{attach_metadata, PreparedMessageSend, SendMessageOutcome};
 use crate::utils::auth::CurrentUid;
 use crate::utils::ids;
@@ -155,6 +155,21 @@ async fn list_pins_in_scope(
     })
 }
 
+/// Who may pin/unpin: DM participants may manage shared pins themselves;
+/// group chats stay admin-only. DM members are all `Member` (no admin exists),
+/// so this replaces the previous unconditional admin requirement.
+fn require_pin_permission(conn: &mut PgConnection, chat_id: i64, uid: i32) -> Result<(), AppError> {
+    let kind: GroupKind = groups::table
+        .find(chat_id)
+        .select(groups::kind)
+        .first(conn)?;
+    if kind == GroupKind::Dm {
+        check_membership(conn, chat_id, uid)
+    } else {
+        require_admin_role(conn, chat_id, uid)
+    }
+}
+
 async fn create_pin_in_scope(
     state: &AppState,
     conn: &mut PgConnection,
@@ -163,7 +178,7 @@ async fn create_pin_in_scope(
     scope: PinScope,
     message_id: i64,
 ) -> Result<PinResponse, AppError> {
-    require_admin_role(conn, chat_id, uid)?;
+    require_pin_permission(conn, chat_id, uid)?;
 
     // Verify message exists in this chat and is not deleted
     let msg: Message = messages::table
@@ -293,7 +308,7 @@ async fn delete_pin_in_scope(
     scope: PinScope,
     pin_id: i64,
 ) -> Result<(), AppError> {
-    require_admin_role(conn, chat_id, uid)?;
+    require_pin_permission(conn, chat_id, uid)?;
 
     let pin: PinnedMessage = pinned_messages::table
         .filter(

--- a/backend/src/handlers/pins.rs
+++ b/backend/src/handlers/pins.rs
@@ -164,7 +164,8 @@ fn require_pin_permission(conn: &mut PgConnection, chat_id: i64, uid: i32) -> Re
         .select(groups::kind)
         .first(conn)?;
     if kind == GroupKind::Dm {
-        check_membership(conn, chat_id, uid)
+        check_membership(conn, chat_id, uid)?;
+        crate::services::social::require_chat_writable(conn, chat_id, uid)
     } else {
         require_admin_role(conn, chat_id, uid)
     }

--- a/backend/src/services/invites.rs
+++ b/backend/src/services/invites.rs
@@ -5,8 +5,8 @@ use uuid::Uuid;
 
 use crate::dto::invites::InviteResponse;
 use crate::errors::AppError;
-use crate::models::{Invite, InviteType, NewInvite};
-use crate::schema::invites;
+use crate::models::{GroupKind, Invite, InviteType, NewInvite};
+use crate::schema::{groups, invites};
 use crate::utils::ids;
 use crate::utils::ids::IdGen;
 
@@ -123,6 +123,17 @@ pub async fn create_invite(
     id_gen: &IdGen,
     input: NewInviteInput,
 ) -> Result<Invite, AppError> {
+    // Single choke point covering the user-facing endpoints and the
+    // service-token external endpoint: no invite may ever target a DM, so
+    // redeeming can never add a third member to one.
+    let kind: GroupKind = groups::table
+        .filter(groups::id.eq(input.chat_id))
+        .select(groups::kind)
+        .first(conn)?;
+    if kind == GroupKind::Dm {
+        return Err(AppError::BadRequest("DM chats cannot have invites"));
+    }
+
     let id = ids::next_id(id_gen).await.map_err(|e| {
         tracing::error!("next_id for invite: {:?}", e);
         AppError::Internal("ID generation failed")

--- a/backend/src/services/messages.rs
+++ b/backend/src/services/messages.rs
@@ -129,7 +129,10 @@ impl From<MessageSendAuthorizationError> for AppError {
                 AppError::BadRequest("Threads can only be created on text messages")
             }
             MessageSendAuthorizationError::InvalidDmParticipants => {
-                AppError::Internal("DM participants missing")
+                // The caller is a member of a DM row but matches neither
+                // dm_uid (e.g. a zombie membership); that is a forbidden
+                // participant, not a server fault.
+                AppError::Forbidden("Not a participant of this chat")
             }
             MessageSendAuthorizationError::DirectMessage(error) => AppError::from(error),
             MessageSendAuthorizationError::Database(error) => AppError::from(error),

--- a/backend/src/services/social.rs
+++ b/backend/src/services/social.rs
@@ -258,6 +258,50 @@ impl From<DmSendAuthorizationError> for AppError {
     }
 }
 
+/// Gate member-initiated writes (pins, edits, deletions, reactions) for a chat:
+/// regular groups are unaffected; a dead DM (friendship ended or blocked either
+/// way) is rejected. Membership is the caller's responsibility.
+pub fn require_chat_writable(
+    conn: &mut PgConnection,
+    chat_id: i64,
+    uid: i32,
+) -> Result<(), AppError> {
+    let (kind, dm_uid1, dm_uid2) = groups::table
+        .filter(groups::id.eq(chat_id))
+        .select((groups::kind, groups::dm_uid1, groups::dm_uid2))
+        .first::<(GroupKind, Option<i32>, Option<i32>)>(conn)?;
+    if kind != GroupKind::Dm {
+        return Ok(());
+    }
+    let peer = match (dm_uid1, dm_uid2) {
+        (Some(uid1), Some(uid2)) if uid1 == uid => uid2,
+        (Some(uid1), Some(uid2)) if uid2 == uid => uid1,
+        _ => return Err(AppError::Forbidden("Not a participant of this chat")),
+    };
+    require_dm_writable(conn, uid, peer)
+}
+
+/// A DM whose friendship has ended (unfriended or blocked either way) keeps its
+/// history readable but accepts no further member-initiated writes: pins,
+/// edits, deletions, and reactions, in addition to the message sends already
+/// blocked by `check_can_dm`. System messages still go through.
+///
+/// The two causes return distinct messages so users can tell a block apart
+/// from an ended friendship.
+fn require_dm_writable(conn: &mut PgConnection, uid: i32, peer: i32) -> Result<(), AppError> {
+    if is_blocked_either_direction(conn, uid, peer)? {
+        return Err(AppError::Forbidden(
+            "This chat is read-only because a block is in place",
+        ));
+    }
+    if !are_mutual_friends(conn, uid, peer)? {
+        return Err(AppError::Forbidden(
+            "This chat is read-only because the friendship has ended",
+        ));
+    }
+    Ok(())
+}
+
 /// Authorize sending a direct message to `peer`.
 pub fn check_can_dm(
     conn: &mut PgConnection,

--- a/wetty-chat-mobile/locales/en/messages.po
+++ b/wetty-chat-mobile/locales/en/messages.po
@@ -1010,6 +1010,9 @@ msgstr "Pin"
 msgid "Pin Message"
 msgstr "Pin Message"
 
+msgid "Pin this message for both of you?"
+msgstr "Pin this message for both of you?"
+
 msgid "Pin this message in the group?"
 msgstr "Pin this message in the group?"
 

--- a/wetty-chat-mobile/locales/zh-CN/messages.po
+++ b/wetty-chat-mobile/locales/zh-CN/messages.po
@@ -1010,6 +1010,9 @@ msgstr "置顶"
 msgid "Pin Message"
 msgstr "置顶消息"
 
+msgid "Pin this message for both of you?"
+msgstr "确定要为你们双方置顶此消息吗？"
+
 msgid "Pin this message in the group?"
 msgstr "确定要置顶此消息吗？"
 

--- a/wetty-chat-mobile/locales/zh-TW/messages.po
+++ b/wetty-chat-mobile/locales/zh-TW/messages.po
@@ -1010,6 +1010,9 @@ msgstr "釘選"
 msgid "Pin Message"
 msgstr "釘選訊息"
 
+msgid "Pin this message for both of you?"
+msgstr "確定要為你們雙方釘選此訊息嗎？"
+
 msgid "Pin this message in the group?"
 msgstr "確定要釘選此訊息嗎？"
 

--- a/wetty-chat-mobile/src/components/chat/pins/PinBanner.tsx
+++ b/wetty-chat-mobile/src/components/chat/pins/PinBanner.tsx
@@ -1,14 +1,13 @@
-import { IonIcon, useIonAlert } from '@ionic/react';
+import { IonIcon } from '@ionic/react';
 import { chatbubbles, close, listOutline, pin } from 'ionicons/icons';
 import { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { t } from '@lingui/core/macro';
 import type { RootState } from '@/store/index';
-import { useChatRole } from '@/components/chat/permissions/useChatRole';
 import { pinScopeKey, selectPinsForScope } from '@/store/pinsSlice';
 import { selectEffectiveLocale } from '@/store/settingsSlice';
-import { deletePin, deleteThreadPin } from '@/api/pins';
 import { formatMessagePreview, getNotificationPreviewLabels } from '@/utils/messagePreview';
+import { usePinManagement } from './usePinManagement';
 import styles from './PinBanner.module.scss';
 
 interface PinBannerProps {
@@ -29,9 +28,7 @@ export function PinBanner({
   onClickThread,
   onClickCounter,
 }: PinBannerProps) {
-  const [presentAlert] = useIonAlert();
-  const { role } = useChatRole(chatId);
-  const isAdmin = role === 'admin';
+  const { canUnpin, confirmUnpin } = usePinManagement(chatId, threadRootId);
   const pins = useSelector((state: RootState) => selectPinsForScope(state, pinScopeKey(chatId, threadRootId)));
   const locale = useSelector(selectEffectiveLocale);
 
@@ -56,25 +53,9 @@ export function PinBanner({
       e.preventDefault();
       e.stopPropagation();
       if (!activePin) return;
-      presentAlert({
-        header: t`Unpin Message`,
-        message: t`Would you like to unpin this message?`,
-        buttons: [
-          { text: t`Cancel`, role: 'cancel' },
-          {
-            text: t`Unpin`,
-            role: 'destructive',
-            handler: () => {
-              const unpin = threadRootId
-                ? deleteThreadPin(chatId, threadRootId, activePin.id)
-                : deletePin(chatId, activePin.id);
-              unpin.catch(() => {});
-            },
-          },
-        ],
-      });
+      confirmUnpin(activePin.id);
     },
-    [chatId, threadRootId, activePin, presentAlert],
+    [activePin, confirmUnpin],
   );
 
   const handleThreadClick = useCallback(
@@ -131,7 +112,7 @@ export function PinBanner({
         </button>
       )}
 
-      {isAdmin && (
+      {canUnpin && (
         <button className={styles.closeBtn} onClick={handleUnpin} aria-label={t`Unpin`}>
           <IonIcon icon={close} />
         </button>

--- a/wetty-chat-mobile/src/components/chat/pins/PinListModal.tsx
+++ b/wetty-chat-mobile/src/components/chat/pins/PinListModal.tsx
@@ -1,15 +1,14 @@
-import { IonButton, IonContent, IonIcon, IonItem, IonList, IonModal, useIonAlert } from '@ionic/react';
+import { IonButton, IonContent, IonIcon, IonItem, IonList, IonModal } from '@ionic/react';
 import { chatbubbles } from 'ionicons/icons';
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { t } from '@lingui/core/macro';
 import type { RootState } from '@/store/index';
-import { useChatRole } from '@/components/chat/permissions/useChatRole';
 import { pinScopeKey, selectPinsForScope } from '@/store/pinsSlice';
 import { selectEffectiveLocale } from '@/store/settingsSlice';
 import type { PinResponse } from '@/api/pins';
-import { deletePin, deleteThreadPin } from '@/api/pins';
 import { formatMessagePreview, getNotificationPreviewLabels } from '@/utils/messagePreview';
+import { usePinManagement } from './usePinManagement';
 import styles from './PinListModal.module.scss';
 import { useIsDesktop } from '@/hooks/platformHooks';
 
@@ -31,10 +30,8 @@ export function PinListModal({
   onSelectPin,
   onSelectThread,
 }: PinListModalProps) {
-  const [presentAlert] = useIonAlert();
   const isDesktop = useIsDesktop();
-  const { role } = useChatRole(chatId);
-  const isAdmin = role === 'admin';
+  const { canUnpin, confirmUnpin } = usePinManagement(chatId, threadRootId);
   const pins = useSelector((state: RootState) => selectPinsForScope(state, pinScopeKey(chatId, threadRootId)));
   const locale = useSelector(selectEffectiveLocale);
 
@@ -50,23 +47,9 @@ export function PinListModal({
     (e: React.MouseEvent, pin: PinResponse) => {
       e.preventDefault();
       e.stopPropagation();
-      presentAlert({
-        header: t`Unpin Message`,
-        message: t`Would you like to unpin this message?`,
-        buttons: [
-          { text: t`Cancel`, role: 'cancel' },
-          {
-            text: t`Unpin`,
-            role: 'destructive',
-            handler: () => {
-              const unpin = threadRootId ? deleteThreadPin(chatId, threadRootId, pin.id) : deletePin(chatId, pin.id);
-              unpin.catch(() => {});
-            },
-          },
-        ],
-      });
+      confirmUnpin(pin.id);
     },
-    [chatId, threadRootId, presentAlert],
+    [confirmUnpin],
   );
 
   const handleThreadClick = useCallback(
@@ -123,7 +106,7 @@ export function PinListModal({
                           <IonIcon icon={chatbubbles} slot="icon-only" className={styles.threadBadge} />
                         </IonButton>
                       )}
-                      {isAdmin && (
+                      {canUnpin && (
                         <IonButton
                           fill="clear"
                           size="small"

--- a/wetty-chat-mobile/src/components/chat/pins/usePinManagement.ts
+++ b/wetty-chat-mobile/src/components/chat/pins/usePinManagement.ts
@@ -1,0 +1,61 @@
+import { useCallback } from 'react';
+import { useIonAlert, useIonToast } from '@ionic/react';
+import { t } from '@lingui/core/macro';
+import { useSelector } from 'react-redux';
+import type { RootState } from '@/store/index';
+import { selectChatMeta } from '@/store/chatsSlice';
+import { useChatRole } from '@/components/chat/permissions/useChatRole';
+import { useDeadDm } from '@/hooks/useDeadDm';
+import { deletePin, deleteThreadPin } from '@/api/pins';
+import { apiErrorMessage } from '@/api/errors';
+
+interface UsePinManagementResult {
+  /** Whether the current user may unpin in this chat (admin, or DM participant of a live DM). */
+  canUnpin: boolean;
+  /** Confirms and executes an unpin, surfacing failures via a toast. */
+  confirmUnpin: (pinId: string) => void;
+}
+
+/**
+ * Shared pin-management policy for the pin banner and pin list modal: who may
+ * unpin, and how a failed unpin is reported. Chat pins and thread pins share
+ * one policy; the thread root is resolved from the optional argument.
+ */
+export function usePinManagement(chatId: string, threadRootId?: string): UsePinManagementResult {
+  const [presentAlert] = useIonAlert();
+  const [presentToast] = useIonToast();
+  const { role } = useChatRole(chatId);
+  const chatMetaKind = useSelector((state: RootState) => selectChatMeta(state, chatId)?.kind);
+  const peerUid = useSelector((state: RootState) => selectChatMeta(state, chatId)?.peer?.uid);
+  const { deadDm } = useDeadDm({ isDm: chatMetaKind === 'dm', peerUid });
+
+  const confirmUnpin = useCallback(
+    (pinId: string) => {
+      presentAlert({
+        header: t`Unpin Message`,
+        message: t`Would you like to unpin this message?`,
+        buttons: [
+          { text: t`Cancel`, role: 'cancel' },
+          {
+            text: t`Unpin`,
+            role: 'destructive',
+            handler: () => {
+              const unpin = threadRootId ? deleteThreadPin(chatId, threadRootId, pinId) : deletePin(chatId, pinId);
+              unpin.catch((err: unknown) => {
+                presentToast({
+                  message: apiErrorMessage(err, t`Failed to unpin message`),
+                  duration: 3000,
+                  position: 'bottom',
+                  cssClass: 'toast-center',
+                });
+              });
+            },
+          },
+        ],
+      });
+    },
+    [chatId, threadRootId, presentAlert, presentToast],
+  );
+
+  return { canUnpin: (role === 'admin' || chatMetaKind === 'dm') && !deadDm, confirmUnpin };
+}

--- a/wetty-chat-mobile/src/pages/conversation/hooks/useMessageOverlayActions.ts
+++ b/wetty-chat-mobile/src/pages/conversation/hooks/useMessageOverlayActions.ts
@@ -239,7 +239,9 @@ export function useMessageOverlayActions({
                   ? t`Would you like to unpin this message?`
                   : threadId
                     ? t`Pin this message in the thread?`
-                    : t`Pin this message in the group?`,
+                    : isDm
+                      ? t`Pin this message for both of you?`
+                      : t`Pin this message in the group?`,
                 buttons: [
                   { text: t`Cancel`, role: 'cancel' },
                   {

--- a/wetty-chat-mobile/src/pages/conversation/utils/overlayActionPolicy.test.ts
+++ b/wetty-chat-mobile/src/pages/conversation/utils/overlayActionPolicy.test.ts
@@ -81,9 +81,24 @@ describe('overlay action policy', () => {
     expect(keys({ isThreadView: true, isAdmin: false })).not.toContain('pin');
   });
 
+  it('offers pin to DM participants without admin role', () => {
+    expect(keys({ isDm: true })).toContain('pin');
+    expect(getOverlayActionPolicy({ ...baseInput, isDm: true, isPinned: true }).at(2)).toEqual({
+      key: 'pin',
+      pinState: 'pinned',
+    });
+  });
+
   it('omits copy-link in DM chats', () => {
     expect(keys({ isDm: true })).not.toContain('copy-link');
-    expect(keys({ isDm: true, hasReactions: true })).toEqual(['reply', 'thread', 'copy', 'save', 'reaction-details']);
+    expect(keys({ isDm: true, hasReactions: true })).toEqual([
+      'reply',
+      'thread',
+      'pin',
+      'copy',
+      'save',
+      'reaction-details',
+    ]);
   });
 
   it('reduces dead DM actions to read-only affordances', () => {
@@ -106,8 +121,8 @@ describe('overlay action policy', () => {
     ]);
   });
 
-  it('does not offer pin for non-admins', () => {
-    expect(keys({ isDm: true })).not.toContain('pin');
+  it('does not offer pin for non-admins in regular group chats', () => {
+    expect(keys({ isDm: false })).not.toContain('pin');
   });
 
   it('does not offer start thread when the message already has thread info', () => {

--- a/wetty-chat-mobile/src/pages/conversation/utils/overlayActionPolicy.ts
+++ b/wetty-chat-mobile/src/pages/conversation/utils/overlayActionPolicy.ts
@@ -55,7 +55,7 @@ export function getOverlayActionPolicy(input: OverlayActionPolicyInput): Overlay
   }
 
   // 3. Pin
-  if (canWrite && !input.isDeleted && input.isAdmin) {
+  if (canWrite && !input.isDeleted && (input.isAdmin || input.isDm)) {
     actions.push({ key: 'pin', pinState: input.isPinned ? 'pinned' : 'unpinned' });
   }
 


### PR DESCRIPTION
- Allow DM participants to pin messages; 
- Make dead DMs read-only — after unfriend/block, history stays readable but pins, edits, deletions, and reactions are rejected;
- Block adding a third member to a DM via explicit `kind == Dm` guards on add-member, role changes, and invite creation;