### PR TITLE
fix(pwa): Keep virtual keyboard open after sending a message

### DIFF
--- a/wetty-chat-mobile/src/components/chat/compose/MessageComposeBar.tsx
+++ b/wetty-chat-mobile/src/components/chat/compose/MessageComposeBar.tsx
@@ -505,6 +505,9 @@ const MessageComposeBarInner = forwardRef<MessageComposeBarHandle, MessageCompos
                 fill="solid"
                 color="primary"
                 className={`${styles.sendBtn}${!canSend ? ` ${styles.disabled}` : ''}`}
+                // Keep focus on the textarea so the virtual keyboard stays open
+                // after sending (mousedown would otherwise move focus to the button).
+                onMouseDown={(e) => e.preventDefault()}
                 onClick={handleSend}
                 aria-label={t`Send message`}
                 disabled={!canSend}


### PR DESCRIPTION
The send button's mousedown moved focus off the textarea, dismissing the keyboard after every send. 