### PR TITLE
[Blocked by angular] fix(pwa): Lock long-press message identity across keyboard-close reflow

### DIFF
--- a/wetty-chat-mobile/src/components/chat/messages/ChatBubble.dom.test.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/ChatBubble.dom.test.tsx
@@ -1,0 +1,166 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatBubble } from './ChatBubble';
+
+// The gesture logic under test lives in ChatBubble's wrapper; stub the visual
+// bubble so no Redux/Ionic/canvas-dependent rendering is pulled in. The stub
+// still mounts the forwarded ref so getBoundingClientRect resolves.
+vi.mock('./ChatBubbleBase', () => ({
+  ChatBubbleBase: ({ bubbleRef }: { bubbleRef?: React.Ref<HTMLDivElement | null> }) => (
+    <div ref={bubbleRef} data-testid="bubble" />
+  ),
+}));
+
+function dispatchTouch(el: Element, type: string, x: number, y: number): Event {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.defineProperty(event, 'touches', { value: [{ clientX: x, clientY: y }] });
+  act(() => {
+    el.dispatchEvent(event);
+  });
+  return event;
+}
+
+describe('ChatBubble long-press gesture', () => {
+  let host: HTMLDivElement;
+  let root: Root;
+  let onLongPress: ReturnType<typeof vi.fn<(rect: DOMRect, pos?: { x: number; y: number }) => void>>;
+  let onReply: ReturnType<typeof vi.fn<() => void>>;
+
+  function renderBubble(props?: { onReply?: () => void; swipeDirection?: 'left' | 'right' }) {
+    act(() => {
+      root.render(
+        <ChatBubble
+          messageType="text"
+          senderName="Alice"
+          message="hello"
+          isSent={false}
+          onLongPress={onLongPress}
+          onReply={props?.onReply ?? onReply}
+          swipeDirection={props?.swipeDirection}
+        />,
+      );
+    });
+    return host.querySelector('[data-testid="bubble"]') as HTMLElement;
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    onLongPress = vi.fn<(rect: DOMRect, pos?: { x: number; y: number }) => void>();
+    onReply = vi.fn<() => void>();
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    host.remove();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('does not fire at 349ms and fires exactly once at 350ms', () => {
+    const bubble = renderBubble();
+    dispatchTouch(bubble, 'touchstart', 12, 34);
+
+    act(() => {
+      vi.advanceTimersByTime(349);
+    });
+    expect(onLongPress).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+    expect(onLongPress.mock.calls[0]?.[1]).toEqual({ x: 12, y: 34 });
+
+    // The fired timer is released: further time never re-fires it.
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    dispatchTouch(bubble, 'touchend', 12, 34);
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels the long-press when the finger moves more than 10px', () => {
+    const bubble = renderBubble();
+    dispatchTouch(bubble, 'touchstart', 0, 0);
+    dispatchTouch(bubble, 'touchmove', 30, 0);
+
+    act(() => {
+      vi.advanceTimersByTime(350);
+    });
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it('cancels the long-press on touchend before the timer expires', () => {
+    const bubble = renderBubble();
+    dispatchTouch(bubble, 'touchstart', 0, 0);
+    dispatchTouch(bubble, 'touchend', 0, 0);
+
+    act(() => {
+      vi.advanceTimersByTime(350);
+    });
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it('cancels the long-press on touchcancel', () => {
+    const bubble = renderBubble();
+    dispatchTouch(bubble, 'touchstart', 0, 0);
+    dispatchTouch(bubble, 'touchcancel', 0, 0);
+
+    act(() => {
+      vi.advanceTimersByTime(350);
+    });
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it('cancels the pending long-press timer on unmount', () => {
+    const bubble = renderBubble();
+    dispatchTouch(bubble, 'touchstart', 0, 0);
+
+    act(() => {
+      root.unmount();
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(350);
+    });
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it('still opens the menu on mouse contextmenu and blocks the browser menu', () => {
+    const bubble = renderBubble();
+
+    const event = new MouseEvent('contextmenu', {
+      bubbles: true,
+      cancelable: true,
+      clientX: 5,
+      clientY: 6,
+    });
+    act(() => {
+      bubble.dispatchEvent(event);
+    });
+
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+    expect(onLongPress.mock.calls[0]?.[1]).toEqual({ x: 5, y: 6 });
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('keeps the horizontal swipe-to-reply gesture working', () => {
+    const bubble = renderBubble({ onReply });
+    dispatchTouch(bubble, 'touchstart', 0, 0);
+    dispatchTouch(bubble, 'touchmove', -70, 0);
+    dispatchTouch(bubble, 'touchend', -70, 0);
+
+    expect(onReply).toHaveBeenCalledTimes(1);
+  });
+});

--- a/wetty-chat-mobile/src/components/chat/messages/ChatBubble.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/ChatBubble.tsx
@@ -150,6 +150,7 @@ export function ChatBubble(props: ChatBubbleProps) {
 
     if (onLongPress) {
       longPressTimer.current = setTimeout(() => {
+        longPressTimer.current = null;
         if (bubbleRef.current) {
           onLongPress(bubbleRef.current.getBoundingClientRect(), {
             x: startX.current,
@@ -207,6 +208,13 @@ export function ChatBubble(props: ChatBubbleProps) {
     setOffset(0);
   }
 
+  function onTouchCancel() {
+    clearLongPress();
+    if (!swiping.current) return;
+    setAnimating(true);
+    setOffset(0);
+  }
+
   function handleContextMenu(e: React.MouseEvent) {
     if (onLongPress && bubbleRef.current) {
       e.preventDefault();
@@ -216,6 +224,16 @@ export function ChatBubble(props: ChatBubbleProps) {
       });
     }
   }
+
+  // A pending long-press timer must not fire after the bubble is gone.
+  useEffect(() => {
+    return () => {
+      if (longPressTimer.current) {
+        clearTimeout(longPressTimer.current);
+        longPressTimer.current = null;
+      }
+    };
+  }, []);
 
   const progress = Math.min(offset / SWIPE_THRESHOLD, 1);
   // Fill only starts after 50% of the threshold — maps progress [0.5,1] → [0,1]
@@ -289,6 +307,7 @@ export function ChatBubble(props: ChatBubbleProps) {
           onTouchStart={onTouchStart}
           onTouchMove={onTouchMove}
           onTouchEnd={onTouchEnd}
+          onTouchCancel={onTouchCancel}
           onContextMenu={handleContextMenu}
           onTransitionEnd={() => setAnimating(false)}
         >

--- a/wetty-chat-mobile/src/pages/conversation/ConversationOverlayHost.tsx
+++ b/wetty-chat-mobile/src/pages/conversation/ConversationOverlayHost.tsx
@@ -5,12 +5,7 @@ import { UserProfileModal } from '@/components/chat/profiles/UserProfileModal';
 import { ReactionDetailsModal } from '@/components/chat/reactions/ReactionDetailsModal';
 import { StickerPreviewModal } from '@/components/chat/compose/StickerPreviewModal';
 import { PinListModal } from '@/components/chat/pins/PinListModal';
-
-interface OverlayMessageState {
-  message: MessageResponse;
-  sourceRect: DOMRect;
-  interactionPos?: { x: number; y: number };
-}
+import type { OverlayRequest } from './hooks/useMessageOverlayCoordinator';
 
 interface ConversationOverlayHostProps {
   chatId: string;
@@ -29,7 +24,7 @@ interface ConversationOverlayHostProps {
   onDismissPinList: () => void;
   onSelectPin: (messageId: string) => void;
   onSelectThread: (messageId: string) => void;
-  overlayMessage: OverlayMessageState | null;
+  overlayMessage: OverlayRequest | null;
   overlayActions: MessageOverlayAction[];
   quickReactionEmojis: string[];
   onReactionToggle: (message: MessageResponse, emoji: string, currentlyReacted: boolean) => void;

--- a/wetty-chat-mobile/src/pages/conversation/conversation.tsx
+++ b/wetty-chat-mobile/src/pages/conversation/conversation.tsx
@@ -36,6 +36,7 @@ import { type ChatMessageEditSession, useChatMessageSender } from './hooks/useCh
 import { useChatReadTracking } from './hooks/useChatReadTracking';
 import { useConversationTimeline } from './hooks/useConversationTimeline';
 import { useKeyboardViewport } from './hooks/useKeyboardViewport';
+import { useMessageOverlayCoordinator } from './hooks/useMessageOverlayCoordinator';
 import { formatUnreadBadge } from '@/utils/unreadBadge';
 import { useMessageOverlayActions } from './hooks/useMessageOverlayActions';
 import { useMessageReactions } from './hooks/useMessageReactions';
@@ -189,20 +190,15 @@ function ConversationPane({ chatId, threadId, backAction }: ConversationPaneProp
   const [editingSession, setEditingSession] = useState<ChatMessageEditSession | null>(null);
   const { handleComposeFocusChange, isKeyboardOpen, keyboardFullyClosed, pageStyle } = useKeyboardViewport(isDesktop);
 
-  const [overlayMessage, setOverlayMessage] = useState<{
-    message: MessageResponse;
-    sourceRect: DOMRect;
-    interactionPos?: { x: number; y: number };
-  } | null>(null);
+  const dismissKeyboard = useCallback(() => {
+    composeBarRef.current?.blurInput();
+  }, []);
 
-  // When a long-press happens while the keyboard is open we defer showing the
-  // overlay until the keyboard has fully closed, while preserving the press-time
-  // rect so the menu stays anchored to the originally pressed message.
-  const deferredOverlayRef = useRef<{
-    message: MessageResponse;
-    sourceRect: DOMRect;
-    interactionPos?: { x: number; y: number };
-  } | null>(null);
+  const { overlayMessage, requestOverlay, closeOverlay } = useMessageOverlayCoordinator({
+    isKeyboardOpen,
+    keyboardFullyClosed,
+    dismissKeyboard,
+  });
 
   useEffect(() => {
     if (!import.meta.env.DEV) return;
@@ -220,14 +216,6 @@ function ConversationPane({ chatId, threadId, backAction }: ConversationPaneProp
       });
     };
   }, [chatId, storeChatId, threadId, location.state]);
-
-  // When the keyboard finishes closing after a deferred long-press, show the overlay.
-  useEffect(() => {
-    if (!keyboardFullyClosed || !deferredOverlayRef.current) return;
-    const { message, sourceRect, interactionPos } = deferredOverlayRef.current;
-    deferredOverlayRef.current = null;
-    setOverlayMessage({ message, sourceRect, interactionPos });
-  }, [keyboardFullyClosed]);
 
   // Auto-redirect from thread view when the root message and all replies are deleted.
   // When a deleted root loses its last reply, threadInfo is cleared → the message is
@@ -362,18 +350,9 @@ function ConversationPane({ chatId, threadId, backAction }: ConversationPaneProp
 
   const onClickChatItem = useCallback(
     (msg: MessageResponse, sourceRect: DOMRect, interactionPos?: { x: number; y: number }) => {
-      if (isKeyboardOpen) {
-        // Defer: dismiss keyboard now, then show the overlay after close while
-        // preserving the original press-time source rect.
-        deferredOverlayRef.current = { message: msg, sourceRect, interactionPos };
-        composeBarRef.current?.blurInput();
-        return;
-      }
-
-      deferredOverlayRef.current = null;
-      setOverlayMessage({ message: msg, sourceRect, interactionPos });
+      requestOverlay({ message: msg, sourceRect, interactionPos });
     },
-    [isKeyboardOpen],
+    [requestOverlay],
   );
 
   const handleSelectThread = useCallback(
@@ -445,11 +424,6 @@ function ConversationPane({ chatId, threadId, backAction }: ConversationPaneProp
     },
     [chatId, messageLookup],
   );
-
-  const handleCloseOverlay = useCallback(() => {
-    deferredOverlayRef.current = null;
-    setOverlayMessage(null);
-  }, []);
 
   const renderRow = useCallback(
     (row: ChatRow) => {
@@ -588,7 +562,7 @@ function ConversationPane({ chatId, threadId, backAction }: ConversationPaneProp
           overlayActions={overlayActions}
           quickReactionEmojis={quickReactionEmojis}
           onReactionToggle={handleReactionToggle}
-          onCloseOverlay={handleCloseOverlay}
+          onCloseOverlay={closeOverlay}
         />
       </div>
     </ChatContext.Provider>

--- a/wetty-chat-mobile/src/pages/conversation/hooks/useMessageOverlayCoordinator.dom.test.tsx
+++ b/wetty-chat-mobile/src/pages/conversation/hooks/useMessageOverlayCoordinator.dom.test.tsx
@@ -1,0 +1,228 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useMessageOverlayCoordinator, type OverlayRequest } from './useMessageOverlayCoordinator';
+
+interface CoordinatorState {
+  overlayMessage: OverlayRequest | null;
+  requestOverlay: (request: OverlayRequest) => boolean;
+  closeOverlay: () => void;
+}
+
+function makeRequest(id: string): OverlayRequest {
+  return {
+    message: { id } as unknown as OverlayRequest['message'],
+    sourceRect: new DOMRect(10, 20, 100, 40),
+  };
+}
+
+describe('useMessageOverlayCoordinator', () => {
+  let host: HTMLDivElement;
+  let root: Root;
+  let state: CoordinatorState;
+  let dismissKeyboard: ReturnType<typeof vi.fn<() => void>>;
+  let manuallyUnmounted = false;
+
+  function render(props?: { isKeyboardOpen?: boolean; keyboardFullyClosed?: boolean }) {
+    const { isKeyboardOpen = false, keyboardFullyClosed = true } = props ?? {};
+    act(() => {
+      root.render(
+        <TestComponent
+          isKeyboardOpen={isKeyboardOpen}
+          keyboardFullyClosed={keyboardFullyClosed}
+          dismissKeyboard={dismissKeyboard}
+          onState={(nextState) => (state = nextState)}
+        />,
+      );
+    });
+  }
+
+  function TestComponent({
+    isKeyboardOpen,
+    keyboardFullyClosed,
+    dismissKeyboard: dismiss,
+    onState,
+  }: {
+    isKeyboardOpen: boolean;
+    keyboardFullyClosed: boolean;
+    dismissKeyboard: () => void;
+    onState: (state: CoordinatorState) => void;
+  }) {
+    const coordinator = useMessageOverlayCoordinator({
+      isKeyboardOpen,
+      keyboardFullyClosed,
+      dismissKeyboard: dismiss,
+    });
+    onState(coordinator);
+    return null;
+  }
+
+  beforeEach(() => {
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    dismissKeyboard = vi.fn<() => void>();
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    if (!manuallyUnmounted) {
+      act(() => {
+        root.unmount();
+      });
+    }
+    host.remove();
+    vi.restoreAllMocks();
+  });
+
+  it('shows the first request immediately when no keyboard is open', () => {
+    render();
+
+    let accepted = false;
+    act(() => {
+      accepted = state.requestOverlay(makeRequest('A'));
+    });
+
+    expect(accepted).toBe(true);
+    expect(state.overlayMessage?.message.id).toBe('A');
+    expect(dismissKeyboard).not.toHaveBeenCalled();
+  });
+
+  it('defers and dismisses the keyboard once when the keyboard is open', () => {
+    render({ isKeyboardOpen: true, keyboardFullyClosed: false });
+
+    let accepted = false;
+    act(() => {
+      accepted = state.requestOverlay(makeRequest('A'));
+    });
+
+    expect(accepted).toBe(true);
+    expect(state.overlayMessage).toBeNull();
+    expect(dismissKeyboard).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a duplicate request while deferred and shows the pressed message after the keyboard closes', () => {
+    render({ isKeyboardOpen: true, keyboardFullyClosed: false });
+
+    act(() => {
+      state.requestOverlay(makeRequest('A'));
+    });
+    let accepted = false;
+    act(() => {
+      accepted = state.requestOverlay(makeRequest('B'));
+    });
+
+    expect(accepted).toBe(false);
+    expect(state.overlayMessage).toBeNull();
+
+    render({ isKeyboardOpen: false, keyboardFullyClosed: true });
+
+    expect(state.overlayMessage?.message.id).toBe('A');
+  });
+
+  it('keeps the pressed message when a late request arrives after the overlay is shown', () => {
+    render({ isKeyboardOpen: true, keyboardFullyClosed: false });
+
+    act(() => {
+      state.requestOverlay(makeRequest('A'));
+    });
+    render({ isKeyboardOpen: false, keyboardFullyClosed: true });
+    expect(state.overlayMessage?.message.id).toBe('A');
+
+    let accepted = true;
+    act(() => {
+      accepted = state.requestOverlay(makeRequest('B'));
+    });
+
+    expect(accepted).toBe(false);
+    expect(state.overlayMessage?.message.id).toBe('A');
+  });
+
+  it('does not reset the overlay when the same message requests again', () => {
+    render();
+
+    act(() => {
+      state.requestOverlay(makeRequest('A'));
+    });
+    const shown = state.overlayMessage;
+
+    let accepted = true;
+    act(() => {
+      accepted = state.requestOverlay(makeRequest('A'));
+    });
+
+    expect(accepted).toBe(false);
+    expect(state.overlayMessage).toBe(shown);
+  });
+
+  it('accepts a new message after the overlay closes', () => {
+    render();
+
+    act(() => {
+      state.requestOverlay(makeRequest('A'));
+    });
+    act(() => {
+      state.closeOverlay();
+    });
+    expect(state.overlayMessage).toBeNull();
+
+    let accepted = false;
+    act(() => {
+      accepted = state.requestOverlay(makeRequest('C'));
+    });
+
+    expect(accepted).toBe(true);
+    expect(state.overlayMessage?.message.id).toBe('C');
+  });
+
+  it('keeps the transaction lock on the immediate path too', () => {
+    render();
+
+    act(() => {
+      state.requestOverlay(makeRequest('A'));
+    });
+
+    let accepted = true;
+    act(() => {
+      accepted = state.requestOverlay(makeRequest('B'));
+    });
+
+    expect(accepted).toBe(false);
+    expect(state.overlayMessage?.message.id).toBe('A');
+  });
+
+  it('does not consume the deferred request twice across repeated viewport updates', () => {
+    render({ isKeyboardOpen: true, keyboardFullyClosed: false });
+
+    act(() => {
+      state.requestOverlay(makeRequest('A'));
+    });
+    render({ isKeyboardOpen: false, keyboardFullyClosed: true });
+    const shown = state.overlayMessage;
+    expect(shown?.message.id).toBe('A');
+
+    render({ isKeyboardOpen: false, keyboardFullyClosed: false });
+    render({ isKeyboardOpen: false, keyboardFullyClosed: true });
+
+    expect(state.overlayMessage).toBe(shown);
+  });
+
+  it('does not update state or call dismiss after unmount', () => {
+    render({ isKeyboardOpen: true, keyboardFullyClosed: false });
+
+    act(() => {
+      state.requestOverlay(makeRequest('A'));
+    });
+    expect(dismissKeyboard).toHaveBeenCalledTimes(1);
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    manuallyUnmounted = true;
+    act(() => {
+      root.unmount();
+    });
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});

--- a/wetty-chat-mobile/src/pages/conversation/hooks/useMessageOverlayCoordinator.ts
+++ b/wetty-chat-mobile/src/pages/conversation/hooks/useMessageOverlayCoordinator.ts
@@ -1,0 +1,81 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { MessageResponse } from '@/api/messages';
+
+export interface OverlayRequest {
+  message: MessageResponse;
+  sourceRect: DOMRect;
+  interactionPos?: { x: number; y: number };
+}
+
+interface UseMessageOverlayCoordinatorOptions {
+  isKeyboardOpen: boolean;
+  keyboardFullyClosed: boolean;
+  dismissKeyboard: () => void;
+}
+
+interface MessageOverlayCoordinator {
+  overlayMessage: OverlayRequest | null;
+  /** Returns false (and changes nothing) when a transaction already owns the message identity. */
+  requestOverlay: (request: OverlayRequest) => boolean;
+  closeOverlay: () => void;
+}
+
+// One long-press gesture is one message-identity transaction. The first accepted
+// request locks the message until the overlay closes. While the soft keyboard
+// closes the page reflows mid-gesture, so the browser's native contextmenu fires
+// later against whichever bubble now sits under the finger — those late requests
+// (from any bubble) must never re-select the message. Two lifecycles live here:
+// the active transaction (lock) and the deferred payload waiting for the
+// keyboard to close; consuming the latter must not release the former.
+export function useMessageOverlayCoordinator({
+  isKeyboardOpen,
+  keyboardFullyClosed,
+  dismissKeyboard,
+}: UseMessageOverlayCoordinatorOptions): MessageOverlayCoordinator {
+  const [overlayMessage, setOverlayMessage] = useState<OverlayRequest | null>(null);
+  // Refs instead of state so adjacent events of the same gesture read the lock
+  // without racing React's commit.
+  const activeLongPressRef = useRef<OverlayRequest | null>(null);
+  const deferredRequestRef = useRef<OverlayRequest | null>(null);
+
+  const requestOverlay = useCallback(
+    (request: OverlayRequest): boolean => {
+      if (activeLongPressRef.current) {
+        return false;
+      }
+
+      activeLongPressRef.current = request;
+      if (isKeyboardOpen) {
+        deferredRequestRef.current = request;
+        dismissKeyboard();
+        return true;
+      }
+
+      setOverlayMessage(request);
+      return true;
+    },
+    [isKeyboardOpen, dismissKeyboard],
+  );
+
+  useEffect(() => {
+    if (!keyboardFullyClosed || !deferredRequestRef.current) return;
+    const request = deferredRequestRef.current;
+    deferredRequestRef.current = null;
+    setOverlayMessage(request);
+  }, [keyboardFullyClosed]);
+
+  const closeOverlay = useCallback(() => {
+    deferredRequestRef.current = null;
+    activeLongPressRef.current = null;
+    setOverlayMessage(null);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      deferredRequestRef.current = null;
+      activeLongPressRef.current = null;
+    };
+  }, []);
+
+  return { overlayMessage, requestOverlay, closeOverlay };
+}

--- a/wetty-chat-mobile/src/test/linguiCoreMacroStub.ts
+++ b/wetty-chat-mobile/src/test/linguiCoreMacroStub.ts
@@ -1,0 +1,4 @@
+// Test stand-in for "@lingui/core/macro" (see vitest.config.ts): identity
+// template tag, so tests render source text without the macro compiler.
+export const t = (strings: TemplateStringsArray, ...values: unknown[]): string =>
+  strings.reduce((text, part, i) => (i === 0 ? part : `${text}${values[i - 1]}${part}`), '');

--- a/wetty-chat-mobile/src/test/linguiReactMacroStub.ts
+++ b/wetty-chat-mobile/src/test/linguiReactMacroStub.ts
@@ -1,0 +1,5 @@
+// Test stand-in for "@lingui/react/macro" (see vitest.config.ts): `Trans`
+// renders its children so source text shows through.
+import type { ReactNode } from 'react';
+
+export const Trans = ({ children }: { children?: ReactNode }) => children;

--- a/wetty-chat-mobile/vitest.config.ts
+++ b/wetty-chat-mobile/vitest.config.ts
@@ -9,6 +9,12 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
+      // Run lingui macros as identity helpers in tests, so the macro compiler
+      // and its optional peer "babel-plugin-macros" (missing on clean CI
+      // installs) never load. One stub per specifier: some tests vi.mock
+      // these two specifiers independently.
+      '@lingui/core/macro': path.resolve(__dirname, './src/test/linguiCoreMacroStub.ts'),
+      '@lingui/react/macro': path.resolve(__dirname, './src/test/linguiReactMacroStub.ts'),
     },
   },
   test: {


### PR DESCRIPTION
Closing the keyboard reflows the page mid-hold, so the browser's native contextmenu fires on whichever message now sits under the finger and replaced the actually-pressed message.
`useMessageOverlayCoordinator` keeps the first long-press message until the overlay closes, hardens ChatBubble's long-press timer cleanup, and covers both race orders with DOM tests.