### PR TITLE
feat(pwa): Add appearance preferences

### DIFF
--- a/wetty-chat-mobile/index.html
+++ b/wetty-chat-mobile/index.html
@@ -53,6 +53,24 @@
         border-top-color: rgba(255, 255, 255, 0.6);
       }
     }
+
+    html.ion-palette-light #bootstrap-splash {
+      background: #f7f7f7;
+    }
+
+    html.ion-palette-light #bootstrap-splash::after {
+      border-color: rgba(0, 0, 0, 0.18);
+      border-top-color: rgba(0, 0, 0, 0.5);
+    }
+
+    html.ion-palette-dark #bootstrap-splash {
+      background: #0d0d0d;
+    }
+
+    html.ion-palette-dark #bootstrap-splash::after {
+      border-color: rgba(255, 255, 255, 0.22);
+      border-top-color: rgba(255, 255, 255, 0.6);
+    }
   </style>
 </head>
 

--- a/wetty-chat-mobile/locales/en/messages.po
+++ b/wetty-chat-mobile/locales/en/messages.po
@@ -103,6 +103,9 @@ msgstr "Anyone can send you a friend request. No verification message is needed;
 msgid "Anyone with this invite link can use it until it expires or is revoked."
 msgstr "Anyone with this invite link can use it until it expires or is revoked."
 
+msgid "Appearance"
+msgstr "Appearance"
+
 msgid "Archive"
 msgstr "Archive"
 
@@ -269,6 +272,9 @@ msgstr "Create new sticker pack"
 
 msgid "Creating…"
 msgstr "Creating…"
+
+msgid "Dark"
+msgstr "Dark"
 
 msgid "Decline all friend requests"
 msgstr "Decline all friend requests"
@@ -606,6 +612,9 @@ msgstr "File is too large. Maximum size is {0}."
 msgid "File is too large. Maximum sticker size is 10 MB."
 msgstr "File is too large. Maximum sticker size is 10 MB."
 
+msgid "Follow System"
+msgstr "Follow System"
+
 msgid "Forever"
 msgstr "Forever"
 
@@ -730,6 +739,9 @@ msgstr "Leaving..."
 
 msgid "Left group"
 msgstr "Left group"
+
+msgid "Light"
+msgstr "Light"
 
 msgid "Link"
 msgstr "Link"

--- a/wetty-chat-mobile/locales/zh-CN/messages.po
+++ b/wetty-chat-mobile/locales/zh-CN/messages.po
@@ -103,6 +103,9 @@ msgstr "任何人都可以向你发送好友请求。无需验证消息，你只
 msgid "Anyone with this invite link can use it until it expires or is revoked."
 msgstr "任何拥有此邀请链接的人都可以在链接过期或被撤销前使用它。"
 
+msgid "Appearance"
+msgstr "外观"
+
 msgid "Archive"
 msgstr "归档"
 
@@ -269,6 +272,9 @@ msgstr "创建新的贴纸包"
 
 msgid "Creating…"
 msgstr "创建中…"
+
+msgid "Dark"
+msgstr "深色"
 
 msgid "Decline all friend requests"
 msgstr "拒绝所有好友请求"
@@ -606,6 +612,9 @@ msgstr "文件过大。最大允许大小为 {0}。"
 msgid "File is too large. Maximum sticker size is 10 MB."
 msgstr "文件过大。贴纸文件大小上限为 10 MB。"
 
+msgid "Follow System"
+msgstr "跟随系统"
+
 msgid "Forever"
 msgstr "永久"
 
@@ -730,6 +739,9 @@ msgstr "正在退出..."
 
 msgid "Left group"
 msgstr "已退出群组"
+
+msgid "Light"
+msgstr "浅色"
 
 msgid "Link"
 msgstr "链接"

--- a/wetty-chat-mobile/locales/zh-TW/messages.po
+++ b/wetty-chat-mobile/locales/zh-TW/messages.po
@@ -103,6 +103,9 @@ msgstr "任何人都可以向你發送好友請求。無需驗證訊息，你只
 msgid "Anyone with this invite link can use it until it expires or is revoked."
 msgstr "任何持有此邀請連結的人都可以在連結到期或被撤銷前使用它。"
 
+msgid "Appearance"
+msgstr "外觀"
+
 msgid "Archive"
 msgstr "封存"
 
@@ -269,6 +272,9 @@ msgstr "建立新的表情包"
 
 msgid "Creating…"
 msgstr "建立中…"
+
+msgid "Dark"
+msgstr "深色"
 
 msgid "Decline all friend requests"
 msgstr "拒絕所有好友請求"
@@ -606,6 +612,9 @@ msgstr "檔案過大。允許的最大大小為 {0}。"
 msgid "File is too large. Maximum sticker size is 10 MB."
 msgstr "檔案過大。貼圖檔案大小上限為 10 MB。"
 
+msgid "Follow System"
+msgstr "跟隨系統"
+
 msgid "Forever"
 msgstr "永久"
 
@@ -730,6 +739,9 @@ msgstr "正在退出..."
 
 msgid "Left group"
 msgstr "已退出群組"
+
+msgid "Light"
+msgstr "淺色"
 
 msgid "Link"
 msgstr "連結"

--- a/wetty-chat-mobile/src/App.tsx
+++ b/wetty-chat-mobile/src/App.tsx
@@ -2,7 +2,7 @@ import { IonApp, IonToast } from '@ionic/react';
 import { IonReactRouter } from '@ionic/react-router';
 import { Redirect, useHistory, useLocation, useRouteMatch } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
-import { useEffect, useRef } from 'react';
+import { useEffect, useLayoutEffect, useRef } from 'react';
 import type { AppDispatch } from '@/store/index';
 import { fetchCurrentUser } from '@/store/userSlice';
 import './app.scss';
@@ -10,7 +10,7 @@ import { t } from '@lingui/core/macro';
 import { isFeatureEnabled } from '@/features';
 import MobileLayout from './layouts/MobileLayout';
 import { AppUpdateProvider } from './hooks/AppUpdateProvider';
-import { useIsDesktop } from './hooks/platformHooks';
+import { useIsDarkMode, useIsDesktop } from './hooks/platformHooks';
 import { useAppLifecycle } from './hooks/useAppLifecycle';
 import { useAppUpdate } from './hooks/useAppUpdate';
 import { usePushNotificationBootstrap } from './hooks/usePushNotifications';
@@ -26,6 +26,7 @@ import { initWebSocket } from '@/api/ws';
 import { appHistory } from '@/utils/navigationHistory';
 import { useNotificationOpenHandler } from '@/hooks/useNotificationOpenHandler';
 import { useQueryTokenAdoption } from '@/hooks/useQueryTokenAdoption';
+import { applyColorMode } from '@/utils/colorMode';
 
 const OOBE_STORAGE_KEY = 'oobe';
 
@@ -102,6 +103,7 @@ function AppRouter({ isDesktop }: { isDesktop: boolean }) {
 function AppShell() {
   const dispatch = useDispatch<AppDispatch>();
   const isDesktop = useIsDesktop();
+  const isDarkMode = useIsDarkMode();
   useAppLifecycle();
   usePushNotificationBootstrap();
   useNotificationOpenHandler();
@@ -111,6 +113,10 @@ function AppShell() {
     initWebSocket();
     dispatch(fetchCurrentUser());
   }, [dispatch]);
+
+  useLayoutEffect(() => {
+    applyColorMode(isDarkMode);
+  }, [isDarkMode]);
 
   return (
     <IonApp>

--- a/wetty-chat-mobile/src/components/chat/messages/MessageOverlay.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/MessageOverlay.tsx
@@ -12,6 +12,7 @@ import styles from './MessageOverlay.module.scss';
 import { MAX_DISTINCT_REACTIONS_PER_MESSAGE } from '@/constants/emojiAndStickers';
 import { getOverlayPortalTarget } from '@/utils/dom';
 import { t } from '@lingui/core/macro';
+import { useIsDarkMode } from '@/hooks/platformHooks';
 
 export interface MessageOverlayAction {
   key: string;
@@ -95,6 +96,7 @@ export function MessageOverlay(props: MessageOverlayProps) {
   const isInvite = props.messageType === 'invite';
   const contentRef = useRef<HTMLDivElement>(null);
   const [isEmojiPickerOpen, setIsEmojiPickerOpen] = useState(false);
+  const isDarkMode = useIsDarkMode();
   const [presentToast] = useIonToast();
 
   const [actionListPage, setActionListPage] = useState(0);
@@ -544,7 +546,7 @@ export function MessageOverlay(props: MessageOverlayProps) {
         >
           <EmojiPicker
             onEmojiClick={handleEmojiClick}
-            theme={Theme.AUTO}
+            theme={isDarkMode ? Theme.DARK : Theme.LIGHT}
             emojiStyle={EmojiStyle.NATIVE}
             lazyLoadEmojis
             previewConfig={{ showPreview: false }}

--- a/wetty-chat-mobile/src/components/chat/settings/ShareInviteModal.tsx
+++ b/wetty-chat-mobile/src/components/chat/settings/ShareInviteModal.tsx
@@ -13,7 +13,7 @@ import {
   useIonActionSheet,
   useIonToast,
 } from '@ionic/react';
-import { close, copyOutline, linkOutline, sendOutline } from 'ionicons/icons';
+import { checkmark, close, copyOutline, linkOutline, sendOutline } from 'ionicons/icons';
 import { t } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
 import { useDispatch } from 'react-redux';
@@ -314,9 +314,11 @@ function ShareInviteModalSession({ chatId, onDismiss }: Omit<ShareInviteModalPro
 
   const handleOpenExpirySelector = () => {
     presentActionSheet({
+      header: t`Expires`,
       buttons: [
         ...getExpiryOptions().map((option) => ({
           text: option.label,
+          icon: option.value === expiryOption ? checkmark : undefined,
           handler: () => changeExpiryOption(option.value),
         })),
         {

--- a/wetty-chat-mobile/src/components/shared/EmojiInput.tsx
+++ b/wetty-chat-mobile/src/components/shared/EmojiInput.tsx
@@ -4,6 +4,7 @@ import EmojiPicker, { EmojiStyle, Theme, type EmojiClickData } from 'emoji-picke
 import { happyOutline } from 'ionicons/icons';
 import { t } from '@lingui/core/macro';
 import { extractEmojiSequences, isEmojiSequence } from '@/utils/emojiSequences';
+import { useIsDarkMode } from '@/hooks/platformHooks';
 import styles from './EmojiInput.module.scss';
 
 interface EmojiInputProps {
@@ -29,6 +30,7 @@ export function EmojiInput({
   maxEmojiCount = 4,
   hideCounter = false,
 }: EmojiInputProps) {
+  const isDarkMode = useIsDarkMode();
   const [isPickerOpen, setIsPickerOpen] = useState(false);
   const [triggerEvent, setTriggerEvent] = useState<Event | undefined>();
   const [popoverSide, setPopoverSide] = useState<'top' | 'bottom'>('bottom');
@@ -143,7 +145,7 @@ export function EmojiInput({
         <div className={styles.pickerCard}>
           <EmojiPicker
             onEmojiClick={handleEmojiClick}
-            theme={Theme.AUTO}
+            theme={isDarkMode ? Theme.DARK : Theme.LIGHT}
             emojiStyle={EmojiStyle.NATIVE}
             lazyLoadEmojis
             searchPlaceholder={t`Search emoji`}

--- a/wetty-chat-mobile/src/features.ts
+++ b/wetty-chat-mobile/src/features.ts
@@ -7,6 +7,10 @@ export const FEATURES = {
     enabled: false,
     description: 'Shows internal developer settings.',
   },
+  colorMode: {
+    enabled: true,
+    description: 'Lets users choose a light, dark, or system color mode.',
+  },
   chatMemberAdd: {
     enabled: false,
     description: 'Allows adding members from the group members page.',

--- a/wetty-chat-mobile/src/hooks/platformHooks.ts
+++ b/wetty-chat-mobile/src/hooks/platformHooks.ts
@@ -1,5 +1,9 @@
 import { isPlatform } from '@ionic/react';
 import { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { isFeatureEnabled } from '@/features';
+import { selectColorMode } from '@/store/settingsSlice';
+import { resolveDarkMode } from '@/utils/colorMode';
 
 const DESKTOP_QUERY = '(min-width: 900px)';
 const HOVER_FINE_POINTER_QUERY = '(any-hover: hover) and (any-pointer: fine)';
@@ -19,7 +23,7 @@ export function useIsDesktop(): boolean {
 
 const DARK_MODE_QUERY = '(prefers-color-scheme: dark)';
 
-export function useIsDarkMode(): boolean {
+function useSystemDarkMode(): boolean {
   const [isDarkMode, setIsDarkMode] = useState(() => window.matchMedia(DARK_MODE_QUERY).matches);
 
   useEffect(() => {
@@ -30,6 +34,13 @@ export function useIsDarkMode(): boolean {
   }, []);
 
   return isDarkMode;
+}
+
+export function useIsDarkMode(): boolean {
+  const systemDarkMode = useSystemDarkMode();
+  const colorMode = useSelector(selectColorMode);
+
+  return isFeatureEnabled('colorMode') ? resolveDarkMode(colorMode, systemDarkMode) : systemDarkMode;
 }
 
 export function useIsPWA(): boolean {

--- a/wetty-chat-mobile/src/layouts/DesktopSplitLayout.tsx
+++ b/wetty-chat-mobile/src/layouts/DesktopSplitLayout.tsx
@@ -21,6 +21,7 @@ import { SettingsCore } from '@/pages/settings';
 import { SavedMessagesCore } from '@/pages/saved-messages';
 import { GeneralSettingsCore } from '@/pages/settings/general';
 import { LanguagePageCore } from '@/pages/settings/language';
+import { ColorModePageCore } from '@/pages/settings/color-mode';
 import { StickerSettingsCore } from '@/pages/settings/stickers';
 import { StickerPackDetailCore } from '@/pages/settings/sticker-pack-detail';
 import { FriendVerificationCore } from '@/pages/settings/friend-verification';
@@ -31,6 +32,7 @@ import { HeaderActionMenu, type HeaderActionMenuItem } from '@/components/Header
 import { useHasGlobalPermission } from '@/hooks/useHasGlobalPermission';
 import { useEscNavigation } from '@/hooks/useEscNavigation';
 import { useFeatureGate } from '@/hooks/useFeatureGate';
+import { isFeatureEnabled } from '@/features';
 import type { RootState } from '@/store';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 
@@ -55,6 +57,7 @@ interface DesktopRouteMatches {
   savedMessagesSettings: boolean;
   friendVerificationSettings: boolean;
   languageSettings: boolean;
+  colorModeSettings: boolean;
   stickerSettings: boolean;
   stickerPackSettings: { packId: string } | null;
 }
@@ -116,6 +119,12 @@ function getDesktopRouteMatches(pathname: string): DesktopRouteMatches {
     path: '/settings/language',
     exact: true,
   });
+  const colorModeSettings =
+    isFeatureEnabled('colorMode') &&
+    !!matchPath(pathname, {
+      path: '/settings/color-mode',
+      exact: true,
+    });
   const generalSettings = !!matchPath(pathname, {
     path: '/settings/general',
     exact: true,
@@ -142,6 +151,7 @@ function getDesktopRouteMatches(pathname: string): DesktopRouteMatches {
     savedMessagesSettings ||
     friendVerificationSettings ||
     languageSettings ||
+    colorModeSettings ||
     stickerSettings;
 
   return {
@@ -172,6 +182,7 @@ function getDesktopRouteMatches(pathname: string): DesktopRouteMatches {
     savedMessagesSettings,
     friendVerificationSettings,
     languageSettings,
+    colorModeSettings,
     stickerSettings,
     stickerPackSettings: stickerPackRaw?.params ?? null,
   };
@@ -365,6 +376,13 @@ export function DesktopSplitLayout() {
   const openLanguageSettings = useCallback(() => {
     history.push({
       pathname: '/settings/language',
+      state: { backgroundPath },
+    });
+  }, [backgroundPath, history]);
+
+  const openColorModeSettings = useCallback(() => {
+    history.push({
+      pathname: '/settings/color-mode',
       state: { backgroundPath },
     });
   }, [backgroundPath, history]);
@@ -568,6 +586,17 @@ export function DesktopSplitLayout() {
                   }),
               }}
             />
+          ) : currentRoute.colorModeSettings ? (
+            <ColorModePageCore
+              backAction={{
+                type: 'callback',
+                onBack: () =>
+                  history.push({
+                    pathname: '/settings/general',
+                    state: { backgroundPath },
+                  }),
+              }}
+            />
           ) : currentRoute.stickerPackSettings ? (
             <StickerPackDetailCore
               packId={currentRoute.stickerPackSettings.packId}
@@ -632,6 +661,7 @@ export function DesktopSplitLayout() {
                   }),
               }}
               onOpenLanguage={openLanguageSettings}
+              onOpenColorMode={openColorModeSettings}
             />
           ) : (
             <SettingsCore

--- a/wetty-chat-mobile/src/layouts/MobileLayout.tsx
+++ b/wetty-chat-mobile/src/layouts/MobileLayout.tsx
@@ -21,6 +21,7 @@ import SettingsPage from '@/pages/settings';
 import SavedMessagesPage from '@/pages/saved-messages';
 import GeneralSettingsPage from '@/pages/settings/general';
 import LanguagePage from '@/pages/settings/language';
+import ColorModePage from '@/pages/settings/color-mode';
 import StickerSettingsPage from '@/pages/settings/stickers';
 import StickerPackDetailPage from '@/pages/settings/sticker-pack-detail';
 import FriendVerificationPage from '@/pages/settings/friend-verification';
@@ -102,6 +103,7 @@ const MobileLayout: React.FC = () => {
         <Route path="/demo" exact component={ComponentDemoPage} />
         <Route path="/settings/general" exact component={GeneralSettingsPage} />
         <Route path="/settings/language" exact component={LanguagePage} />
+        {whenFeature('colorMode', <Route path="/settings/color-mode" exact component={ColorModePage} />)}
         {whenFeature('savedMessages', <Route path="/settings/saved-messages" exact component={SavedMessagesPage} />)}
         {whenFeature(
           'friends',

--- a/wetty-chat-mobile/src/main.tsx
+++ b/wetty-chat-mobile/src/main.tsx
@@ -13,7 +13,7 @@ import '@ionic/react/css/text-alignment.css';
 import '@ionic/react/css/text-transformation.css';
 import '@ionic/react/css/flex-utils.css';
 import '@ionic/react/css/display.css';
-import '@ionic/react/css/palettes/dark.system.css';
+import '@ionic/react/css/palettes/dark.class.css';
 
 import { createRoot } from 'react-dom/client';
 import { Provider } from 'react-redux';
@@ -30,6 +30,8 @@ import {
 import { hydrateStickerPreferences } from '@/store/stickerPreferencesSlice';
 import { installBootstrapRecoveryHandlers } from '@/bootstrapRecovery';
 import { bootstrapAuth } from '@/authBootstrap';
+import { isFeatureEnabled } from '@/features';
+import { applyColorMode, getSystemDarkMode, resolveDarkMode } from '@/utils/colorMode';
 import App from './App';
 import AuthBootstrapGate from '@/components/bootstrap/AuthBootstrapGate';
 import { setupIonicReact } from '@ionic/react';
@@ -54,6 +56,8 @@ async function bootstrap() {
     ]);
 
   const settings = hydrateSettings(savedSettings);
+  const systemDarkMode = getSystemDarkMode();
+  applyColorMode(isFeatureEnabled('colorMode') ? resolveDarkMode(settings.colorMode, systemDarkMode) : systemDarkMode);
 
   if (hasLegacyChatListSettings(savedSettings)) {
     await kvSet('settings', serializeSettings(settings));

--- a/wetty-chat-mobile/src/pages/conversation/ChatAdminSettings.tsx
+++ b/wetty-chat-mobile/src/pages/conversation/ChatAdminSettings.tsx
@@ -76,6 +76,8 @@ export function ChatAdminSettings({
             </IonLabel>
             <IonSelect
               value={visibility}
+              interface="action-sheet"
+              cancelText={t`Cancel`}
               onIonChange={(event) => onVisibilityChange(event.detail.value as 'public' | 'private')}
             >
               <IonSelectOption value="public">

--- a/wetty-chat-mobile/src/pages/invite-preview.module.scss
+++ b/wetty-chat-mobile/src/pages/invite-preview.module.scss
@@ -6,7 +6,7 @@
     var(--ion-background-color, #ffffff) 100%
   );
 
-  @media (prefers-color-scheme: dark) {
+  :global(html.ion-palette-dark) & {
     --background: var(--ion-background-color, #000);
   }
 }
@@ -18,7 +18,7 @@
   border-radius: 28px;
   box-shadow: 0 18px 50px rgba(0, 0, 0, 0.12);
 
-  @media (prefers-color-scheme: dark) {
+  :global(html.ion-palette-dark) & {
     box-shadow: 0 18px 50px rgba(0, 0, 0, 0.4);
   }
   border: 1px solid var(--ion-border-color, rgba(0, 0, 0, 0.12));

--- a/wetty-chat-mobile/src/pages/settings/color-mode.tsx
+++ b/wetty-chat-mobile/src/pages/settings/color-mode.tsx
@@ -1,0 +1,77 @@
+import { t } from '@lingui/core/macro';
+import { Trans } from '@lingui/react/macro';
+import {
+  IonBackButton,
+  IonButtons,
+  IonContent,
+  IonHeader,
+  IonIcon,
+  IonItem,
+  IonLabel,
+  IonList,
+  IonPage,
+  IonTitle,
+  IonToolbar,
+} from '@ionic/react';
+import { checkmark } from 'ionicons/icons';
+import type { ReactNode } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useHistory } from 'react-router-dom';
+import { BackButton } from '@/components/BackButton';
+import { selectColorMode, setColorMode } from '@/store/settingsSlice';
+import type { BackAction } from '@/types/back-action';
+import type { ColorMode } from '@/utils/colorMode';
+
+interface ColorModePageCoreProps {
+  backAction?: BackAction;
+}
+
+const colorModeOptions: Array<{ value: ColorMode; label: ReactNode }> = [
+  { value: 'system', label: <Trans>Follow System</Trans> },
+  { value: 'light', label: <Trans>Light</Trans> },
+  { value: 'dark', label: <Trans>Dark</Trans> },
+];
+
+export function ColorModePageCore({ backAction }: ColorModePageCoreProps) {
+  const dispatch = useDispatch();
+  const history = useHistory();
+  const colorMode = useSelector(selectColorMode);
+
+  const handleSelect = (nextColorMode: ColorMode) => {
+    dispatch(setColorMode(nextColorMode));
+    history.goBack();
+  };
+
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonButtons slot="start">
+            {backAction ? (
+              <BackButton action={backAction} />
+            ) : (
+              <IonBackButton text={t`Back`} defaultHref="/settings/general" />
+            )}
+          </IonButtons>
+          <IonTitle>
+            <Trans>Appearance</Trans>
+          </IonTitle>
+        </IonToolbar>
+      </IonHeader>
+      <IonContent color="light">
+        <IonList>
+          {colorModeOptions.map(({ value, label }) => (
+            <IonItem key={value} button detail={false} onClick={() => handleSelect(value)}>
+              <IonLabel>{label}</IonLabel>
+              {colorMode === value && <IonIcon icon={checkmark} slot="end" color="primary" />}
+            </IonItem>
+          ))}
+        </IonList>
+      </IonContent>
+    </IonPage>
+  );
+}
+
+export default function ColorModePage() {
+  return <ColorModePageCore />;
+}

--- a/wetty-chat-mobile/src/pages/settings/general.tsx
+++ b/wetty-chat-mobile/src/pages/settings/general.tsx
@@ -22,6 +22,7 @@ import { BackButton } from '@/components/BackButton';
 import { ChatBubble } from '@/components/chat/messages/ChatBubble';
 import {
   chatFontSizeOptions,
+  selectColorMode,
   selectLocale,
   selectMessageFontSize,
   selectShowAllAvatars,
@@ -30,12 +31,15 @@ import {
   setShowAllAvatars,
   setShowThreadsInMessages,
 } from '@/store/settingsSlice';
+import { FeatureGate } from '@/components/FeatureGate';
 import type { BackAction } from '@/types/back-action';
+import type { ColorMode } from '@/utils/colorMode';
 import styles from './GeneralSettings.module.scss';
 
 interface GeneralSettingsCoreProps {
   backAction?: BackAction;
   onOpenLanguage?: () => void;
+  onOpenColorMode?: () => void;
 }
 
 const localeLabels: Record<string, string> = {
@@ -44,10 +48,22 @@ const localeLabels: Record<string, string> = {
   'zh-TW': '繁體中文',
 };
 
-export function GeneralSettingsCore({ backAction, onOpenLanguage }: GeneralSettingsCoreProps) {
+function getColorModeLabel(colorMode: ColorMode): string {
+  switch (colorMode) {
+    case 'light':
+      return t`Light`;
+    case 'dark':
+      return t`Dark`;
+    case 'system':
+      return t`Follow System`;
+  }
+}
+
+export function GeneralSettingsCore({ backAction, onOpenLanguage, onOpenColorMode }: GeneralSettingsCoreProps) {
   const dispatch = useDispatch();
   const history = useHistory();
   const locale = useSelector(selectLocale);
+  const colorMode = useSelector(selectColorMode);
   const messageFontSize = useSelector(selectMessageFontSize);
   const showThreadsInMessages = useSelector(selectShowThreadsInMessages);
   const showAllAvatars = useSelector(selectShowAllAvatars);
@@ -59,6 +75,14 @@ export function GeneralSettingsCore({ backAction, onOpenLanguage }: GeneralSetti
       return;
     }
     history.push('/settings/language');
+  };
+
+  const handleOpenColorMode = () => {
+    if (onOpenColorMode) {
+      onOpenColorMode();
+      return;
+    }
+    history.push('/settings/color-mode');
   };
 
   return (
@@ -83,6 +107,16 @@ export function GeneralSettingsCore({ backAction, onOpenLanguage }: GeneralSetti
               {locale ? (localeLabels[locale] ?? locale) : t`Auto`}
             </IonLabel>
           </IonItem>
+          <FeatureGate feature="colorMode">
+            <IonItem button detail={true} onClick={handleOpenColorMode}>
+              <IonLabel>
+                <Trans>Appearance</Trans>
+              </IonLabel>
+              <IonLabel slot="end" color="medium">
+                {getColorModeLabel(colorMode)}
+              </IonLabel>
+            </IonItem>
+          </FeatureGate>
           <IonItem>
             <IonToggle
               checked={showThreadsInMessages}

--- a/wetty-chat-mobile/src/store/settingsSlice.test.ts
+++ b/wetty-chat-mobile/src/store/settingsSlice.test.ts
@@ -13,13 +13,14 @@ describe('settings migration', () => {
     expect(hasLegacyChatListSettings(saved)).toBe(true);
 
     const hydrated = hydrateSettings(saved);
-    expect(hydrated).toMatchObject({ showThreadsInMessages: true, chatListTab: 'messages' });
+    expect(hydrated).toMatchObject({ colorMode: 'system', showThreadsInMessages: true, chatListTab: 'messages' });
     expect(hydrated).not.toHaveProperty('showAllTab');
     expect(hydrated).not.toHaveProperty('showGroupsTab');
     expect(hydrated).not.toHaveProperty('showFriendsTab');
     expect(hydrated).not.toHaveProperty('showThreadsTab');
     expect(serializeSettings(hydrated)).toEqual({
       locale: null,
+      colorMode: 'system',
       messageFontSize: 'medium',
       showThreadsInMessages: true,
       showAllAvatars: false,

--- a/wetty-chat-mobile/src/store/settingsSlice.ts
+++ b/wetty-chat-mobile/src/store/settingsSlice.ts
@@ -3,6 +3,7 @@ import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice, current } from '@reduxjs/toolkit';
 import type { RootState } from './index';
 import { kvSet } from '@/utils/db';
+import { isColorMode, type ColorMode } from '@/utils/colorMode';
 
 export const supportedLocales = ['en', 'zh-CN', 'zh-TW'];
 export const defaultLocale = 'en';
@@ -30,6 +31,7 @@ export function detectLocale(): string {
 
 export interface SettingsState {
   locale: string | null;
+  colorMode: ColorMode;
   messageFontSize: ChatFontSizeOption;
   showThreadsInMessages: boolean;
   showAllAvatars: boolean;
@@ -66,6 +68,7 @@ function normalizePinnedReactions(reactions: string[]): string[] {
 export function serializeSettings(state: SettingsState) {
   return {
     locale: state.locale,
+    colorMode: state.colorMode,
     messageFontSize: state.messageFontSize,
     showThreadsInMessages: state.showThreadsInMessages,
     showAllAvatars: state.showAllAvatars,
@@ -89,6 +92,7 @@ export function getChatFontSizeStyle(messageFontSize: ChatFontSizeOption): strin
 
 const defaultSettings: SettingsState = {
   locale: null,
+  colorMode: 'system',
   messageFontSize: defaultChatFontSize,
   showThreadsInMessages: true,
   showAllAvatars: false,
@@ -107,6 +111,7 @@ export function hydrateSettings(saved: StoredSettings | null | undefined): Setti
   return {
     ...defaultSettings,
     ...persistedSettings,
+    colorMode: isColorMode(saved?.colorMode) ? saved.colorMode : defaultSettings.colorMode,
     messageFontSize: isChatFontSizeOption(saved?.messageFontSize) ? saved.messageFontSize : defaultChatFontSize,
     pinnedReactions: normalizePinnedReactions(saved?.pinnedReactions ?? defaultSettings.pinnedReactions),
     recentReactions: saved?.recentReactions ?? defaultSettings.recentReactions,
@@ -123,6 +128,10 @@ const settingsSlice = createSlice({
       state.locale = action.payload;
       persistSettings(state);
       persistEffectiveLocale(state.locale);
+    },
+    setColorMode(state, action: PayloadAction<ColorMode>) {
+      state.colorMode = action.payload;
+      persistSettings(state);
     },
     setMessageFontSize(state, action: PayloadAction<ChatFontSizeOption>) {
       state.messageFontSize = action.payload;
@@ -155,6 +164,7 @@ const settingsSlice = createSlice({
 
 export const {
   setLocale,
+  setColorMode,
   setMessageFontSize,
   setShowThreadsInMessages,
   setChatListTab,
@@ -163,6 +173,7 @@ export const {
   addRecentReaction,
 } = settingsSlice.actions;
 export const selectLocale = (state: RootState) => state.settings.locale;
+export const selectColorMode = (state: RootState) => state.settings.colorMode;
 export const selectEffectiveLocale = (state: RootState) => state.settings.locale ?? detectLocale();
 export const selectMessageFontSize = (state: RootState) => state.settings.messageFontSize;
 export const selectShowThreadsInMessages = (state: RootState) => state.settings.showThreadsInMessages;

--- a/wetty-chat-mobile/src/utils/colorMode.ts
+++ b/wetty-chat-mobile/src/utils/colorMode.ts
@@ -1,0 +1,32 @@
+export const colorModes = ['system', 'light', 'dark'] as const;
+export type ColorMode = (typeof colorModes)[number];
+
+const DARK_MODE_QUERY = '(prefers-color-scheme: dark)';
+const LIGHT_THEME_COLOR = '#f7f7f7';
+const DARK_THEME_COLOR = '#0d0d0d';
+
+export function isColorMode(value: unknown): value is ColorMode {
+  return typeof value === 'string' && colorModes.includes(value as ColorMode);
+}
+
+export function getSystemDarkMode(): boolean {
+  return typeof window !== 'undefined' && window.matchMedia(DARK_MODE_QUERY).matches;
+}
+
+export function resolveDarkMode(colorMode: ColorMode, systemDarkMode: boolean): boolean {
+  if (colorMode === 'dark') return true;
+  if (colorMode === 'light') return false;
+  return systemDarkMode;
+}
+
+export function applyColorMode(isDarkMode: boolean) {
+  const root = document.documentElement;
+  root.classList.toggle('ion-palette-dark', isDarkMode);
+  root.classList.toggle('ion-palette-light', !isDarkMode);
+  root.style.colorScheme = isDarkMode ? 'dark' : 'light';
+
+  const themeColor = isDarkMode ? DARK_THEME_COLOR : LIGHT_THEME_COLOR;
+  document.querySelectorAll<HTMLMetaElement>('meta[name="theme-color"]').forEach((meta) => {
+    meta.content = themeColor;
+  });
+}


### PR DESCRIPTION
Adds a persistent Appearance setting with System, Light, and Dark modes.

- Applies the selected theme across Ionic UI, chat colors, emoji pickers, previews, and browser theme color.
- Uses a dedicated Appearance subpage on mobile and desktop settings.
- Standardizes short setting choices with action sheets for group visibility and invite expiration.