### PR TITLE
feat(backend): mention notifications backend part

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,6 @@
 *.sln
 *.sw?
 .cursor
-.pi/
-context.md
 .env
 
 # Where I keep my runspace for testing / docker compose

--- a/backend/migrations/2026-09-10-235325-0000_add_notifications/down.sql
+++ b/backend/migrations/2026-09-10-235325-0000_add_notifications/down.sql
@@ -1,0 +1,11 @@
+DROP INDEX idx_message_reactions_author_created;
+
+ALTER TABLE message_reactions DROP COLUMN message_author_uid;
+
+ALTER TABLE thread_user_states DROP COLUMN last_reactions_read_at;
+
+ALTER TABLE group_membership DROP COLUMN last_reactions_read_at;
+
+DROP TABLE message_mentions;
+
+DROP TYPE mention_kind;

--- a/backend/migrations/2026-09-10-235325-0000_add_notifications/up.sql
+++ b/backend/migrations/2026-09-10-235325-0000_add_notifications/up.sql
@@ -1,0 +1,51 @@
+-- Mentions and replies share one unread-notification pipeline. A row records
+-- either an explicit @mention or a reply to one of the target's messages.
+CREATE TYPE mention_kind AS ENUM ('mention', 'reply');
+
+CREATE TABLE message_mentions (
+    message_id     BIGINT NOT NULL REFERENCES messages(id),
+    mentioned_uid  INTEGER NOT NULL,
+    chat_id        BIGINT NOT NULL REFERENCES groups(id),
+    thread_root_id BIGINT NULL,
+    kind           mention_kind NOT NULL DEFAULT 'mention',
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (message_id, mentioned_uid)
+);
+
+-- Supports unread mention counts and jump-to-mention in main and thread scopes.
+CREATE INDEX message_mentions_unread_idx
+    ON message_mentions (mentioned_uid, chat_id, thread_root_id, message_id);
+
+-- Reactions have a timestamp cursor because message read pointers cannot record
+-- when a user has seen a reaction. The default prevents pre-deploy reactions
+-- from becoming unread notifications.
+ALTER TABLE group_membership
+    ADD COLUMN last_reactions_read_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
+ALTER TABLE thread_user_states
+    ADD COLUMN last_reactions_read_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
+-- Denormalize the target message author so unread reaction queries can filter
+-- and range-scan the reactions table without scanning historical messages.
+ALTER TABLE message_reactions
+    ADD COLUMN message_author_uid INTEGER;
+
+-- Legacy rows may outlive their soft-deleted target messages. They cannot
+-- produce a notification and have no author to denormalize.
+DELETE FROM message_reactions mr
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM messages m
+    WHERE m.id = mr.message_id
+);
+
+UPDATE message_reactions mr
+SET message_author_uid = m.sender_uid
+FROM messages m
+WHERE m.id = mr.message_id;
+
+ALTER TABLE message_reactions
+    ALTER COLUMN message_author_uid SET NOT NULL;
+
+CREATE INDEX idx_message_reactions_author_created
+    ON message_reactions (message_author_uid, created_at);

--- a/backend/src/dto/chats.rs
+++ b/backend/src/dto/chats.rs
@@ -15,6 +15,10 @@ pub struct ChatListItem {
     pub avatar: Option<String>,
     pub last_message_at: Option<DateTime<Utc>>,
     pub unread_count: i64,
+    pub unread_mentions: i64,
+    /// Unread-reaction message count (reactions on my messages newer than my
+    /// reaction cursor). Never folded into `unread_count`.
+    pub unread_reactions: i64,
     #[serde(with = "crate::serde_i64_string::opt")]
     #[schema(value_type = Option<String>)]
     pub last_read_message_id: Option<i64>,
@@ -42,6 +46,8 @@ pub struct MarkChatReadStateResponse {
     #[schema(value_type = Option<String>)]
     pub last_read_message_id: Option<i64>,
     pub unread_count: i64,
+    pub unread_mentions: i64,
+    pub unread_reactions: i64,
 }
 
 #[derive(Serialize, utoipa::ToSchema)]
@@ -51,4 +57,20 @@ pub struct UnreadCountResponse {
     pub archived_unread_count: i64,
     pub unread_chat_count: i64,
     pub archived_unread_chat_count: i64,
+    pub unread_mentions: i64,
+}
+
+#[derive(Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct UnreadMentionIdsResponse {
+    /// Unread mention message ids, newest-first. Serialized as strings (JS-safe).
+    pub message_ids: Vec<String>,
+}
+
+#[derive(Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct UnreadReactionIdsResponse {
+    /// Message ids with unread reactions, newest-first, one entry per message
+    /// regardless of how many new reactions it carries. Serialized as strings.
+    pub message_ids: Vec<String>,
 }

--- a/backend/src/dto/threads.rs
+++ b/backend/src/dto/threads.rs
@@ -17,6 +17,8 @@ pub struct ThreadListItem {
     pub reply_count: i64,
     pub last_reply_at: DateTime<Utc>,
     pub unread_count: i64,
+    pub unread_mentions: i64,
+    pub unread_reactions: i64,
     #[serde(with = "crate::serde_i64_string::opt")]
     #[schema(value_type = Option<String>)]
     pub last_read_message_id: Option<i64>,
@@ -38,6 +40,8 @@ pub struct MarkThreadReadResponse {
     #[schema(value_type = Option<String>)]
     pub last_read_message_id: Option<i64>,
     pub unread_count: i64,
+    pub unread_mentions: i64,
+    pub unread_reactions: i64,
 }
 
 #[derive(Serialize, utoipa::ToSchema)]

--- a/backend/src/dto/ws.rs
+++ b/backend/src/dto/ws.rs
@@ -44,6 +44,7 @@ pub enum ServerWsMessage {
     FriendRequestReceived(FriendRequestReceivedPayload),
     FriendRequestResolved(FriendRequestResolvedPayload),
     FriendshipRemoved(FriendshipRemovedPayload),
+    Notification(NotificationPayload),
 }
 
 impl ServerWsMessage {
@@ -66,6 +67,7 @@ impl ServerWsMessage {
             Self::FriendRequestReceived(_) => "friendRequestReceived",
             Self::FriendRequestResolved(_) => "friendRequestResolved",
             Self::FriendshipRemoved(_) => "friendshipRemoved",
+            Self::Notification(_) => "notification",
         }
     }
 }
@@ -175,10 +177,41 @@ pub struct FriendshipRemovedPayload {
     pub actor_uid: i32,
 }
 
+/// Kind of directed notification delivered to a specific user.
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum NotificationType {
+    Mention,
+    Reply,
+    Reaction,
+}
+
+/// Directed notification to a specific user about a mention, a reply to one of
+/// their messages, or a reaction on one of their messages. Delivered only to
+/// the affected user via the realtime WebSocket.
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct NotificationPayload {
+    pub notification_type: NotificationType,
+    #[serde(with = "crate::serde_i64_string")]
+    #[schema(value_type = String)]
+    pub chat_id: i64,
+    #[serde(with = "crate::serde_i64_string")]
+    #[schema(value_type = String)]
+    pub message_id: i64,
+    #[serde(with = "crate::serde_i64_string::opt")]
+    #[schema(value_type = Option<String>)]
+    pub thread_root_id: Option<i64>,
+    pub actor_uid: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub actor_name: Option<String>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        PinUpdatePayload, PresenceUpdatePayload, ServerWsMessage, ThreadMembershipChangedPayload,
+        NotificationPayload, NotificationType, PinUpdatePayload, PresenceUpdatePayload,
+        ServerWsMessage, ThreadMembershipChangedPayload,
     };
     use serde_json::json;
 
@@ -252,5 +285,61 @@ mod tests {
 
         assert_eq!(value["type"], json!("pinRemoved"));
         assert!(value["payload"].get("threadRootId").is_none());
+    }
+
+    #[test]
+    fn serializes_notification_event_as_camel_case() {
+        let value = serde_json::to_value(ServerWsMessage::Notification(NotificationPayload {
+            notification_type: NotificationType::Mention,
+            chat_id: 7,
+            message_id: 42,
+            thread_root_id: Some(99),
+            actor_uid: 5,
+            actor_name: Some("alice".to_string()),
+        }))
+        .expect("serialize notification event");
+
+        assert_eq!(value["type"], json!("notification"));
+        assert_eq!(value["payload"]["notificationType"], json!("mention"));
+        assert_eq!(value["payload"]["chatId"], json!("7"));
+        assert_eq!(value["payload"]["messageId"], json!("42"));
+        assert_eq!(value["payload"]["threadRootId"], json!("99"));
+        assert_eq!(value["payload"]["actorUid"], json!(5));
+        assert_eq!(value["payload"]["actorName"], json!("alice"));
+        assert!(value["payload"].get("chat_id").is_none());
+    }
+
+    #[test]
+    fn serializes_reply_notification_type_as_reply() {
+        let value = serde_json::to_value(ServerWsMessage::Notification(NotificationPayload {
+            notification_type: NotificationType::Reply,
+            chat_id: 7,
+            message_id: 42,
+            thread_root_id: None,
+            actor_uid: 5,
+            actor_name: None,
+        }))
+        .expect("serialize reply notification event");
+
+        assert_eq!(value["payload"]["notificationType"], json!("reply"));
+        assert_eq!(value["payload"]["threadRootId"], json!(null));
+        assert!(value["payload"].get("actorName").is_none());
+    }
+
+    #[test]
+    fn serializes_reaction_notification_type_as_reaction() {
+        let value = serde_json::to_value(ServerWsMessage::Notification(NotificationPayload {
+            notification_type: NotificationType::Reaction,
+            chat_id: 7,
+            message_id: 42,
+            thread_root_id: None,
+            actor_uid: 5,
+            actor_name: None,
+        }))
+        .expect("serialize reaction notification event");
+
+        assert_eq!(value["payload"]["notificationType"], json!("reaction"));
+        assert_eq!(value["payload"]["threadRootId"], json!(null));
+        assert!(value["payload"].get("actorName").is_none());
     }
 }

--- a/backend/src/handlers/chats/messages.rs
+++ b/backend/src/handlers/chats/messages.rs
@@ -13,7 +13,7 @@ use crate::schema::messages::dsl;
 use crate::{
     dto::{
         messages::{ListMessagesResponse, MessageResponse, SearchMessagesResponse},
-        ws::ServerWsMessage,
+        ws::{NotificationPayload, NotificationType, ServerWsMessage},
     },
     errors::AppError,
     extractors::DbConn,
@@ -34,8 +34,9 @@ use crate::{
 use super::{ChatIdPath, CreateMessageBody};
 use crate::services::authz::Action as AuthzAction;
 use crate::services::messages::{
-    attach_metadata, authorize_message_send, extract_mention_uids, parse_attachment_ids,
-    send_prepared_message, validate_message, PreparedMessageSend, SendMessageOutcome,
+    attach_metadata, authorize_message_send, extract_mention_uids, load_username_by_uid,
+    parse_attachment_ids, send_prepared_message, sync_edited_message_mentions, validate_message,
+    PreparedMessageSend, SendMessageOutcome,
 };
 use crate::services::social;
 #[derive(serde::Deserialize, utoipa::ToSchema)]
@@ -834,7 +835,7 @@ async fn patch_message(
 
     let attachment_ids = parse_attachment_ids(&body.attachment_ids)?;
     let now = Utc::now();
-    let updated_message: Message = conn.transaction::<_, AppError, _>(|conn| {
+    let (updated_message, added_mention_uids) = conn.transaction::<_, AppError, _>(|conn| {
         use crate::schema::attachments::dsl as a_dsl;
         let message: Message = messages::table
             .filter(dsl::id.eq(message_id).and(dsl::chat_id.eq(chat_id)))
@@ -898,20 +899,30 @@ async fn patch_message(
                 return Err(AppError::BadRequest("Invalid attachment selection"));
             }
         }
-        diesel::update(messages::table.filter(dsl::id.eq(message_id)))
-            .set((
-                dsl::message.eq(&body.message),
-                dsl::has_attachments.eq(!attachment_ids.is_empty()),
-                dsl::updated_at.eq(Some(now)),
-            ))
-            .returning(Message::as_returning())
-            .get_result(conn)
-            .map_err(Into::into)
+        let updated_message: Message =
+            diesel::update(messages::table.filter(dsl::id.eq(message_id)))
+                .set((
+                    dsl::message.eq(&body.message),
+                    dsl::has_attachments.eq(!attachment_ids.is_empty()),
+                    dsl::updated_at.eq(Some(now)),
+                ))
+                .returning(Message::as_returning())
+                .get_result(conn)?;
+
+        // Keep @mention rows in step with the edited body: dropping a mention
+        // clears the stale unread entry, adding one inserts it (member-filtered,
+        // excluding the editor) and auto-subscribes thread replies.
+        let added_mention_uids =
+            sync_edited_message_mentions(conn, &message, &body.message, uid, now)?;
+
+        Ok((updated_message, added_mention_uids))
     })?;
 
     if let Some(search_service) = state.message_search.clone() {
         search_service.upsert_message_best_effort(updated_message.clone());
     }
+
+    let edited_thread_root_id = updated_message.reply_root_id;
 
     let response = attach_metadata(
         conn,
@@ -935,6 +946,25 @@ async fn patch_message(
     };
     let ws_msg = std::sync::Arc::new(ServerWsMessage::MessageUpdated(response.clone()));
     state.ws_registry.broadcast_to_uids(&member_uids, ws_msg);
+
+    // Notify members newly mentioned by the edit. The mention rows are synced
+    // inside the transaction above; this is the realtime counterpart, fired
+    // post-commit like the send path.
+    if !added_mention_uids.is_empty() {
+        let actor_name = load_username_by_uid(conn, uid)?.unwrap_or_else(|| "Someone".to_string());
+        let payload = NotificationPayload {
+            notification_type: NotificationType::Mention,
+            chat_id,
+            message_id,
+            thread_root_id: edited_thread_root_id,
+            actor_uid: uid,
+            actor_name: Some(actor_name),
+        };
+        state.ws_registry.broadcast_to_uids(
+            &added_mention_uids,
+            std::sync::Arc::new(ServerWsMessage::Notification(payload)),
+        );
+    }
 
     Ok(Json(response))
 }
@@ -998,6 +1028,13 @@ async fn delete_message(
                 .set(dsl::deleted_at.eq(Some(now)))
                 .returning(Message::as_returning())
                 .get_result(conn)?;
+
+        // Clean up @mention rows for the deleted message.
+        {
+            use crate::schema::message_mentions::dsl as mm_dsl;
+            diesel::delete(mm_dsl::message_mentions.filter(mm_dsl::message_id.eq(message_id)))
+                .execute(conn)?;
+        }
 
         if let Some(reply_root_id) = deleted_message.reply_root_id {
             crate::services::threads::recalculate_thread_meta(conn, chat_id, reply_root_id)?;

--- a/backend/src/handlers/chats/mod.rs
+++ b/backend/src/handlers/chats/mod.rs
@@ -15,7 +15,10 @@ use utoipa_axum::router::OpenApiRouter;
 
 use crate::{
     dto::{
-        chats::{ChatListItem, ListChatsResponse, MarkChatReadStateResponse, UnreadCountResponse},
+        chats::{
+            ChatListItem, ListChatsResponse, MarkChatReadStateResponse, UnreadCountResponse,
+            UnreadMentionIdsResponse, UnreadReactionIdsResponse,
+        },
         messages::MessageResponse,
         ws::{ChatArchiveStateChangedPayload, ServerWsMessage},
     },
@@ -276,6 +279,12 @@ async fn get_chats(
     let unread_counts = state
         .unread_service
         .count_membership_unreads(conn, &memberships)?;
+    let mention_counts = state
+        .unread_service
+        .count_user_chat_unread_mentions(conn, uid)?;
+    let reaction_counts = state
+        .unread_service
+        .count_user_chat_unread_reactions(conn, uid)?;
 
     let message_responses =
         attach_metadata(conn, messages_to_process, &state.media, &state.avatars, uid).await;
@@ -319,6 +328,8 @@ async fn get_chats(
                 dm_uid2,
             )| {
                 let unread_count = unread_counts.get(&id).copied().unwrap_or(0);
+                let unread_mentions = mention_counts.get(&id).copied().unwrap_or(0);
+                let unread_reactions = reaction_counts.get(&id).copied().unwrap_or(0);
                 let mr = msg
                     .and_then(|m| message_response_map.remove(&m.id))
                     .map(message_response_preview);
@@ -340,6 +351,8 @@ async fn get_chats(
                         .map(|storage_key| state.media.public_url(storage_key)),
                     last_message_at,
                     unread_count,
+                    unread_mentions,
+                    unread_reactions,
                     last_read_message_id,
                     last_message: mr,
                     muted_until,
@@ -397,9 +410,24 @@ async fn mark_as_read(
         body.message_id,
     )?;
 
+    let unread_mentions = state.unread_service.count_chat_unread_mentions(
+        conn,
+        uid,
+        chat_id,
+        read_state.last_read_message_id,
+        None,
+    )?;
+    // The reaction cursor was just advanced by mark_chat_as_read, so this is
+    // normally 0; computed for consistency with the mention count.
+    let unread_reactions = state
+        .unread_service
+        .count_chat_unread_reactions(conn, uid, chat_id, None)?;
+
     Ok(Json(MarkChatReadStateResponse {
         last_read_message_id: read_state.last_read_message_id,
         unread_count: read_state.unread_count,
+        unread_mentions,
+        unread_reactions,
     }))
 }
 
@@ -492,9 +520,21 @@ async fn mark_as_unread(
         (new_read_id, unread_count)
     };
 
+    let unread_mentions =
+        state
+            .unread_service
+            .count_chat_unread_mentions(conn, uid, chat_id, new_read_id, None)?;
+    // Marking unread rewinds the message pointer only; the reaction cursor
+    // never moves backwards, so this reports the live (unchanged) count.
+    let unread_reactions = state
+        .unread_service
+        .count_chat_unread_reactions(conn, uid, chat_id, None)?;
+
     Ok(Json(MarkChatReadStateResponse {
         last_read_message_id: new_read_id,
         unread_count,
+        unread_mentions,
+        unread_reactions,
     }))
 }
 
@@ -531,10 +571,136 @@ async fn get_chat_unread_count(
         state
             .unread_service
             .count_chat_unread(conn, chat_id, last_read_message_id)?;
+    let unread_mentions = state.unread_service.count_chat_unread_mentions(
+        conn,
+        uid,
+        chat_id,
+        last_read_message_id,
+        None,
+    )?;
+    let unread_reactions = state
+        .unread_service
+        .count_chat_unread_reactions(conn, uid, chat_id, None)?;
 
     Ok(Json(MarkChatReadStateResponse {
         last_read_message_id,
         unread_count,
+        unread_mentions,
+        unread_reactions,
+    }))
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct UnreadMentionsQuery {
+    #[serde(
+        default,
+        deserialize_with = "crate::serde_i64_string::opt::deserialize"
+    )]
+    thread_id: Option<i64>,
+    #[serde(default)]
+    max: Option<i64>,
+}
+
+/// GET /chats/{chat_id}/mentions - Unread @mention message ids for the current user.
+///
+/// Returns main-scope mentions by default; pass `threadId` for thread-scope mentions.
+/// Ids are newest-first (default 1000, hard cap 1000). A mention is
+/// unread while `message_id > last_read_message_id` (cursor-derived; no per-mention flag).
+#[utoipa::path(
+    get,
+    path = "/mentions",
+    params(
+        ("chat_id" = i64, Path, description = "Chat ID"),
+        ("threadId" = Option<String>, Query, description = "Thread root message id; omit for main-scope mentions"),
+        ("max" = Option<i64>, Query, description = "Max ids to return (default 1000, capped at 1000)"),
+    ),
+    responses(
+        (status = 200, description = "Unread mention message ids, newest-first", body = UnreadMentionIdsResponse),
+    ),
+    security(("uid_header" = []), ("bearer_jwt" = [])),
+)]
+async fn get_chat_mentions(
+    CurrentUid(uid): CurrentUid,
+    State(state): State<AppState>,
+    Path(ChatIdPath { chat_id }): Path<ChatIdPath>,
+    mut conn: DbConn,
+    Query(q): Query<UnreadMentionsQuery>,
+) -> Result<Json<UnreadMentionIdsResponse>, AppError> {
+    let conn = &mut *conn;
+
+    check_membership(conn, chat_id, uid)?;
+
+    let limit = validate_limit(q.max, crate::constants::MAX_UNREAD_COUNT);
+
+    let (last_read_message_id, thread_root_id) = match q.thread_id {
+        Some(thread_id) => {
+            let last_read = crate::services::threads::get_thread_last_read_message_id(
+                conn, chat_id, thread_id, uid,
+            )?;
+            (last_read, Some(thread_id))
+        }
+        None => {
+            let last_read = chat::get_chat_last_read_message_id(conn, chat_id, uid)?;
+            (last_read, None)
+        }
+    };
+
+    let ids = state.unread_service.list_chat_unread_mentions(
+        conn,
+        uid,
+        chat_id,
+        last_read_message_id,
+        thread_root_id,
+        limit,
+    )?;
+
+    Ok(Json(UnreadMentionIdsResponse {
+        message_ids: ids.into_iter().map(|id| id.to_string()).collect(),
+    }))
+}
+
+/// GET /chats/{chat_id}/reactions - Message ids with unread reactions for the current user.
+///
+/// Returns main-scope reactions by default (reactions on the user's top-level
+/// messages); pass `threadId` for reactions on the user's messages in that
+/// thread. Ids are newest-first, one entry per message regardless of how many
+/// new reactions it carries (default 1000, hard cap 1000). A reaction is
+/// unread while `created_at > last_reactions_read_at` (cursor-derived; the
+/// cursor advances on mark-read).
+#[utoipa::path(
+    get,
+    path = "/reactions",
+    params(
+        ("chat_id" = i64, Path, description = "Chat ID"),
+        ("threadId" = Option<String>, Query, description = "Thread root message id; omit for main-scope reactions"),
+        ("max" = Option<i64>, Query, description = "Max ids to return (default 1000, capped at 1000)"),
+    ),
+    responses(
+        (status = 200, description = "Message ids with unread reactions, newest-first", body = UnreadReactionIdsResponse),
+    ),
+    security(("uid_header" = []), ("bearer_jwt" = [])),
+)]
+async fn get_chat_reactions(
+    CurrentUid(uid): CurrentUid,
+    State(state): State<AppState>,
+    Path(ChatIdPath { chat_id }): Path<ChatIdPath>,
+    mut conn: DbConn,
+    Query(q): Query<UnreadMentionsQuery>,
+) -> Result<Json<UnreadReactionIdsResponse>, AppError> {
+    let conn = &mut *conn;
+
+    check_membership(conn, chat_id, uid)?;
+
+    let limit = validate_limit(q.max, crate::constants::MAX_UNREAD_COUNT);
+
+    let ids =
+        state
+            .unread_service
+            .list_chat_unread_reactions(conn, uid, chat_id, q.thread_id, limit)?;
+
+    Ok(Json(UnreadReactionIdsResponse {
+        message_ids: ids.into_iter().map(|id| id.to_string()).collect(),
     }))
 }
 
@@ -556,12 +722,22 @@ async fn get_unread_count(
     let conn = &mut *conn;
 
     let counts = state.unread_service.count_user_unread_summary(conn, uid)?;
+    let mention_counts = state
+        .unread_service
+        .count_user_chat_unread_mentions(conn, uid)?;
+    // Reaction badges are list-only by design and never join this global
+    // aggregation (see `count_user_chat_unread_reactions`).
+    let unread_mentions = mention_counts.values().copied().fold(0i64, |acc, n| {
+        acc.saturating_add(n)
+            .min(crate::constants::MAX_UNREAD_COUNT)
+    });
 
     Ok(Json(UnreadCountResponse {
         unread_count: counts.unread_count,
         archived_unread_count: counts.archived_unread_count,
         unread_chat_count: counts.unread_chat_count,
         archived_unread_chat_count: counts.archived_unread_chat_count,
+        unread_mentions,
     }))
 }
 
@@ -685,6 +861,8 @@ pub fn router() -> OpenApiRouter<crate::AppState> {
                 .routes(utoipa_axum::routes!(mark_as_read))
                 .routes(utoipa_axum::routes!(mark_as_unread))
                 .routes(utoipa_axum::routes!(get_chat_unread_count))
+                .routes(utoipa_axum::routes!(get_chat_mentions))
+                .routes(utoipa_axum::routes!(get_chat_reactions))
                 .routes(utoipa_axum::routes!(self::messages::post_thread_message))
                 .nest("/threads/{thread_root_id}", super::threads::thread_router())
                 .nest("/saved-messages", self::saved_messages::router())

--- a/backend/src/handlers/chats/reactions.rs
+++ b/backend/src/handlers/chats/reactions.rs
@@ -49,7 +49,7 @@ fn broadcast_reaction_update(
     state: &AppState,
     chat_id: i64,
     message_id: i64,
-) {
+) -> Vec<i32> {
     let counts: Vec<(String, i64)> = message_reactions::table
         .filter(message_reactions::message_id.eq(message_id))
         .group_by(message_reactions::emoji)
@@ -117,6 +117,7 @@ fn broadcast_reaction_update(
         reactions,
     }));
     state.ws_registry.broadcast_to_uids(&member_uids, ws_msg);
+    member_uids
 }
 
 #[utoipa::path(
@@ -255,12 +256,12 @@ async fn put_reaction(
         .set(messages::has_reactions.eq(true))
         .execute(conn)?;
 
-    broadcast_reaction_update(conn, &state, chat_id, message_id);
+    let member_uids = broadcast_reaction_update(conn, &state, chat_id, message_id);
 
     // Directed unread-reaction notification to the message author. Only on a
     // genuinely new row (re-putting the same emoji is a no-op) and never for
-    // self-reactions; the unread count is derived from the same rows.
-    if inserted > 0 && message.sender_uid != uid {
+    // self-reactions or authors who are no longer chat members.
+    if inserted > 0 && message.sender_uid != uid && member_uids.contains(&message.sender_uid) {
         let actor_name = load_username_by_uid(conn, uid)?.unwrap_or_else(|| "Someone".to_string());
         let payload = NotificationPayload {
             notification_type: NotificationType::Reaction,
@@ -335,7 +336,7 @@ async fn delete_reaction(
                 .execute(conn)?;
         }
 
-        broadcast_reaction_update(conn, &state, chat_id, message_id);
+        let _ = broadcast_reaction_update(conn, &state, chat_id, message_id);
     }
 
     Ok(StatusCode::NO_CONTENT)

--- a/backend/src/handlers/chats/reactions.rs
+++ b/backend/src/handlers/chats/reactions.rs
@@ -12,7 +12,7 @@ use utoipa_axum::router::OpenApiRouter;
 use crate::{
     dto::{
         messages::{ReactionDetailGroup, ReactionDetailResponse, ReactionReactor, ReactionSummary},
-        ws::{ReactionUpdatePayload, ServerWsMessage},
+        ws::{NotificationPayload, NotificationType, ReactionUpdatePayload, ServerWsMessage},
     },
     errors::AppError,
     extractors::DbConn,
@@ -23,7 +23,7 @@ use crate::{
     AppState,
 };
 
-use crate::services::messages::load_usernames_by_uids;
+use crate::services::messages::{load_username_by_uid, load_usernames_by_uids};
 use crate::services::social;
 
 fn validate_emoji(input: &str) -> Result<String, AppError> {
@@ -229,7 +229,7 @@ async fn put_reaction(
     social::require_chat_writable(conn, chat_id, uid)?;
 
     // Verify message exists and belongs to this chat
-    let _message: Message = messages::table
+    let message: Message = messages::table
         .filter(messages::id.eq(message_id))
         .filter(messages::chat_id.eq(chat_id))
         .filter(messages::deleted_at.is_null())
@@ -239,12 +239,13 @@ async fn put_reaction(
         .ok_or(AppError::NotFound("Message not found"))?;
 
     // Insert reaction (ON CONFLICT DO NOTHING for idempotency)
-    diesel::insert_into(message_reactions::table)
+    let inserted = diesel::insert_into(message_reactions::table)
         .values(&MessageReaction {
             message_id,
             user_uid: uid,
             emoji,
             created_at: Utc::now(),
+            message_author_uid: message.sender_uid,
         })
         .on_conflict_do_nothing()
         .execute(conn)?;
@@ -255,6 +256,25 @@ async fn put_reaction(
         .execute(conn)?;
 
     broadcast_reaction_update(conn, &state, chat_id, message_id);
+
+    // Directed unread-reaction notification to the message author. Only on a
+    // genuinely new row (re-putting the same emoji is a no-op) and never for
+    // self-reactions; the unread count is derived from the same rows.
+    if inserted > 0 && message.sender_uid != uid {
+        let actor_name = load_username_by_uid(conn, uid)?.unwrap_or_else(|| "Someone".to_string());
+        let payload = NotificationPayload {
+            notification_type: NotificationType::Reaction,
+            chat_id,
+            message_id,
+            thread_root_id: message.reply_root_id,
+            actor_uid: uid,
+            actor_name: Some(actor_name),
+        };
+        state.ws_registry.broadcast_to_uids(
+            &[message.sender_uid],
+            std::sync::Arc::new(ServerWsMessage::Notification(payload)),
+        );
+    }
 
     Ok(StatusCode::NO_CONTENT)
 }

--- a/backend/src/handlers/threads.rs
+++ b/backend/src/handlers/threads.rs
@@ -18,6 +18,7 @@ use crate::{
     models::Message,
     schema::messages,
     services::threads as thread_svc,
+    services::unread::UnreadService,
     utils::{auth::CurrentUid, pagination::validate_limit},
     AppState,
 };
@@ -163,6 +164,7 @@ fn authorize_thread_in_chat(
 /// Callers MUST have authorized `uid` for `chat_id` first.
 fn apply_thread_read(
     conn: &mut PgConnection,
+    unread_service: &UnreadService,
     chat_id: i64,
     thread_root_id: i64,
     uid: i32,
@@ -174,15 +176,33 @@ fn apply_thread_read(
         return Ok(MarkThreadReadResponse {
             last_read_message_id: None,
             unread_count: 0,
+            unread_mentions: 0,
+            unread_reactions: 0,
         });
     }
 
     let _ = thread_svc::ensure_thread_user_state(conn, chat_id, thread_root_id, uid, false)?;
     let read_state = thread_svc::mark_thread_read(conn, chat_id, thread_root_id, uid, message_id)?;
+    // Thread-scope unread mentions left past the new read cursor, mirroring the
+    // per-chat mark-as-read response so clients can keep the badge accurate
+    // without a separate fetch.
+    let unread_mentions = unread_service.count_chat_unread_mentions(
+        conn,
+        uid,
+        chat_id,
+        read_state.last_read_message_id,
+        Some(thread_root_id),
+    )?;
+    // The reaction cursor was advanced by mark_thread_as_read, so this is
+    // normally 0; computed for consistency with the mention count.
+    let unread_reactions =
+        unread_service.count_chat_unread_reactions(conn, uid, chat_id, Some(thread_root_id))?;
 
     Ok(MarkThreadReadResponse {
         last_read_message_id: read_state.last_read_message_id,
         unread_count: read_state.unread_count,
+        unread_mentions,
+        unread_reactions,
     })
 }
 
@@ -205,6 +225,7 @@ fn apply_thread_read(
 )]
 async fn mark_thread_read(
     CurrentUid(uid): CurrentUid,
+    State(state): State<AppState>,
     Path(ThreadRootIdPath { thread_root_id }): Path<ThreadRootIdPath>,
     mut conn: DbConn,
     Json(body): Json<MarkThreadReadBody>,
@@ -216,6 +237,7 @@ async fn mark_thread_read(
 
     Ok(Json(apply_thread_read(
         conn,
+        &state.unread_service,
         chat_id,
         thread_root_id,
         uid,
@@ -309,6 +331,7 @@ pub struct ThreadSubscribePath {
 )]
 async fn mark_thread_read_in_chat(
     CurrentUid(uid): CurrentUid,
+    State(state): State<AppState>,
     Path(ThreadSubscribePath {
         chat_id,
         thread_root_id,
@@ -322,6 +345,7 @@ async fn mark_thread_read_in_chat(
 
     Ok(Json(apply_thread_read(
         conn,
+        &state.unread_service,
         chat_id,
         thread_root_id,
         uid,

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -135,6 +135,15 @@ pub enum MessageType {
     System,
 }
 
+/// Why a `message_mentions` row exists: an explicit @mention in the message
+/// body, or the message being a reply to one of the target's messages.
+#[derive(diesel_derive_enum::DbEnum, Debug, Clone, Copy, PartialEq, Eq)]
+#[ExistingTypePath = "crate::schema::sql_types::MentionKind"]
+pub enum MentionKind {
+    Mention,
+    Reply,
+}
+
 #[derive(
     diesel_derive_enum::DbEnum,
     Debug,
@@ -576,6 +585,20 @@ pub struct MessageReaction {
     pub user_uid: i32,
     pub emoji: String,
     pub created_at: DateTime<Utc>,
+    /// Author of the reacted message, denormalized so unread-reaction queries
+    /// can filter "reactions on my messages" without scanning messages.
+    pub message_author_uid: i32,
+}
+
+#[derive(Debug, Clone, Queryable, Selectable, Insertable)]
+#[diesel(table_name = schema::message_mentions)]
+pub struct MessageMention {
+    pub message_id: i64,
+    pub mentioned_uid: i32,
+    pub chat_id: i64,
+    pub thread_root_id: Option<i64>,
+    pub created_at: DateTime<Utc>,
+    pub kind: MentionKind,
 }
 
 #[derive(Debug, Clone, Queryable, Selectable, Serialize)]

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -7,11 +7,11 @@ use discuz::discuz::{common_member, common_usergroup};
 use discuz_manual::discuz::common_member_profile;
 pub use primary::{
     activity_daily_metrics, attachments, blocks, clients, friend_requests, friendships,
-    group_membership, groups, invites, media, message_reactions, messages, pinned_messages,
-    policies, policy_assignments, policy_permissions, push_subscriptions, saved_messages,
-    service_tokens, sql_types, sticker_pack_stickers, sticker_packs, stickers, thread_meta,
-    thread_user_states, user_extra, user_favorite_stickers, user_sticker_pack_subscriptions,
-    usergroup_extra,
+    group_membership, groups, invites, media, message_mentions, message_reactions, messages,
+    pinned_messages, policies, policy_assignments, policy_permissions, push_subscriptions,
+    saved_messages, service_tokens, sql_types, sticker_pack_stickers, sticker_packs, stickers,
+    thread_meta, thread_user_states, user_extra, user_favorite_stickers,
+    user_sticker_pack_subscriptions, usergroup_extra,
 };
 
 diesel::allow_tables_to_appear_in_same_query!(group_membership, common_member);

--- a/backend/src/schema/primary.rs
+++ b/backend/src/schema/primary.rs
@@ -34,6 +34,10 @@ pub mod sql_types {
     pub struct MediaPurpose;
 
     #[derive(diesel::query_builder::QueryId, diesel::sql_types::SqlType)]
+    #[diesel(postgres_type(name = "mention_kind"))]
+    pub struct MentionKind;
+
+    #[derive(diesel::query_builder::QueryId, diesel::sql_types::SqlType)]
     #[diesel(postgres_type(name = "message_type"))]
     pub struct MessageType;
 
@@ -149,6 +153,7 @@ diesel::table! {
         join_reason -> GroupJoinReason,
         join_reason_extra -> Nullable<Jsonb>,
         archived -> Bool,
+        last_reactions_read_at -> Timestamptz,
     }
 }
 
@@ -216,12 +221,27 @@ diesel::table! {
 }
 
 diesel::table! {
+    use diesel::sql_types::*;
+    use super::sql_types::MentionKind;
+
+    message_mentions (message_id, mentioned_uid) {
+        message_id -> Int8,
+        mentioned_uid -> Int4,
+        chat_id -> Int8,
+        thread_root_id -> Nullable<Int8>,
+        created_at -> Timestamptz,
+        kind -> MentionKind,
+    }
+}
+
+diesel::table! {
     message_reactions (message_id, user_uid, emoji) {
         message_id -> Int8,
         user_uid -> Int4,
         #[max_length = 32]
         emoji -> Varchar,
         created_at -> Timestamptz,
+        message_author_uid -> Int4,
     }
 }
 
@@ -413,6 +433,7 @@ diesel::table! {
         subscribed_at -> Timestamptz,
         archived -> Bool,
         subscribed -> Bool,
+        last_reactions_read_at -> Timestamptz,
     }
 }
 
@@ -460,6 +481,7 @@ diesel::table! {
 diesel::joinable!(attachments -> messages (message_id));
 diesel::joinable!(group_membership -> groups (chat_id));
 diesel::joinable!(groups -> media (avatar_image_id));
+diesel::joinable!(message_mentions -> messages (message_id));
 diesel::joinable!(message_reactions -> messages (message_id));
 diesel::joinable!(messages -> stickers (sticker_id));
 diesel::joinable!(pinned_messages -> groups (chat_id));
@@ -487,6 +509,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     groups,
     invites,
     media,
+    message_mentions,
     message_reactions,
     messages,
     pinned_messages,

--- a/backend/src/schema/primary.rs
+++ b/backend/src/schema/primary.rs
@@ -229,8 +229,8 @@ diesel::table! {
         mentioned_uid -> Int4,
         chat_id -> Int8,
         thread_root_id -> Nullable<Int8>,
-        created_at -> Timestamptz,
         kind -> MentionKind,
+        created_at -> Timestamptz,
     }
 }
 
@@ -481,6 +481,7 @@ diesel::table! {
 diesel::joinable!(attachments -> messages (message_id));
 diesel::joinable!(group_membership -> groups (chat_id));
 diesel::joinable!(groups -> media (avatar_image_id));
+diesel::joinable!(message_mentions -> groups (chat_id));
 diesel::joinable!(message_mentions -> messages (message_id));
 diesel::joinable!(message_reactions -> messages (message_id));
 diesel::joinable!(messages -> stickers (sticker_id));

--- a/backend/src/services/background/mod.rs
+++ b/backend/src/services/background/mod.rs
@@ -251,25 +251,38 @@ fn process_bulk_delete(
 
         let now = Utc::now();
 
-        // Soft-delete the batch of messages
-        diesel::update(messages::table.filter(dsl::id.eq_any(&batch_ids)))
-            .set(dsl::deleted_at.eq(Some(now)))
-            .execute(conn)
-            .map_err(map_db)?;
+        // Atomic per batch: soft-delete, mention cleanup, and attachment
+        // soft-delete commit together — a crash between statements would leave
+        // mention rows (counted without checking deleted_at) or live attachments
+        // pointing at soft-deleted messages.
+        conn.transaction::<_, diesel::result::Error, _>(|conn| {
+            diesel::update(messages::table.filter(dsl::id.eq_any(&batch_ids)))
+                .set(dsl::deleted_at.eq(Some(now)))
+                .execute(conn)?;
+
+            {
+                use crate::schema::message_mentions::dsl as mm_dsl;
+                diesel::delete(
+                    mm_dsl::message_mentions.filter(mm_dsl::message_id.eq_any(&batch_ids)),
+                )
+                .execute(conn)?;
+            }
+
+            diesel::update(
+                attachments::table
+                    .filter(a_dsl::message_id.eq_any(&batch_ids))
+                    .filter(a_dsl::deleted_at.is_null()),
+            )
+            .set(a_dsl::deleted_at.eq(Some(now)))
+            .execute(conn)?;
+
+            Ok(())
+        })
+        .map_err(map_db)?;
 
         if let Some(search_service) = message_search {
             search_service.delete_message_ids_best_effort(batch_ids.clone());
         }
-
-        // Soft-delete attachments for these messages
-        diesel::update(
-            attachments::table
-                .filter(a_dsl::message_id.eq_any(&batch_ids))
-                .filter(a_dsl::deleted_at.is_null()),
-        )
-        .set(a_dsl::deleted_at.eq(Some(now)))
-        .execute(conn)
-        .map_err(map_db)?;
 
         // Broadcast MessagesBulkDeleted for this batch
         let ws_msg = Arc::new(ServerWsMessage::MessagesBulkDeleted(BulkDeletedPayload {

--- a/backend/src/services/chat.rs
+++ b/backend/src/services/chat.rs
@@ -51,6 +51,17 @@ pub fn mark_chat_as_read(
     .set(gm_dsl::last_read_message_id.eq(Some(message_id)))
     .execute(conn)?;
 
+    // Advancing the read position also acknowledges unread reactions: they are
+    // derived from a reaction-timestamp cursor (see UnreadService), which only
+    // moves forward.
+    diesel::update(
+        group_membership::table
+            .filter(gm_dsl::chat_id.eq(chat_id))
+            .filter(gm_dsl::uid.eq(uid)),
+    )
+    .set(gm_dsl::last_reactions_read_at.eq(Utc::now()))
+    .execute(conn)?;
+
     Ok(updated > 0)
 }
 

--- a/backend/src/services/messages.rs
+++ b/backend/src/services/messages.rs
@@ -16,14 +16,15 @@ use crate::{
             StickerMediaResponse, ThreadInfo,
         },
         users::User,
-        ws::ServerWsMessage,
+        ws::{NotificationPayload, NotificationType, ServerWsMessage},
     },
     errors::AppError,
     models::{
-        Attachment, GroupKind, Media, Message, MessageType, NewMessage, Sticker, TranscodeStatus,
+        Attachment, GroupKind, Media, MentionKind, Message, MessageMention, MessageType,
+        NewMessage, Sticker, TranscodeStatus,
     },
     schema::{
-        attachments, group_membership, groups, media, message_reactions,
+        attachments, group_membership, groups, media, message_mentions, message_reactions,
         messages as messages_schema, stickers, user_favorite_stickers,
     },
     services::{
@@ -162,6 +163,7 @@ pub struct PendingSideEffects {
     pub ws_msg: std::sync::Arc<ServerWsMessage>,
     pub broadcast_uids: Vec<i32>,
     pub push_job: Option<PushJob>,
+    pub notifications: Vec<(i32, std::sync::Arc<ServerWsMessage>)>,
     pub unread_event: Option<TopLevelUnreadCacheEvent>,
 }
 
@@ -187,6 +189,21 @@ impl PendingSideEffects {
         if let Some(job) = self.push_job {
             state.push_service.enqueue(job);
         }
+        // The send path clones one payload Arc for every mentioned member; group
+        // adjacent equal payloads so each broadcast goes out in a single registry
+        // pass instead of one call per user.
+        let mut batched: Vec<(std::sync::Arc<ServerWsMessage>, Vec<i32>)> = Vec::new();
+        for (uid, msg) in self.notifications {
+            match batched.last_mut() {
+                Some((last_msg, last_uids)) if std::sync::Arc::ptr_eq(last_msg, &msg) => {
+                    last_uids.push(uid);
+                }
+                _ => batched.push((msg, vec![uid])),
+            }
+        }
+        for (msg, uids) in batched {
+            state.ws_registry.broadcast_to_uids(&uids, msg);
+        }
     }
 }
 
@@ -194,7 +211,7 @@ impl PendingSideEffects {
 // Shared helper functions
 // ---------------------------------------------------------------------------
 
-fn load_username_by_uid(conn: &mut PgConnection, uid: i32) -> QueryResult<Option<String>> {
+pub fn load_username_by_uid(conn: &mut PgConnection, uid: i32) -> QueryResult<Option<String>> {
     lookup_user_profiles(conn, &[uid])
         .map(|mut profiles| profiles.remove(&uid).and_then(|profile| profile.username))
 }
@@ -492,7 +509,6 @@ fn sticker_preview_text(emoji: Option<&str>) -> String {
 struct PushPreviewBundle {
     message_preview: PushMessagePreview,
     body_preview: Option<String>,
-    mentioned_uids: Vec<i32>,
 }
 
 /// Replace `@[uid:N]` tokens with `@username` for human-readable previews.
@@ -527,11 +543,6 @@ fn render_mentions_as_text(text: &str, mentions: &[MentionInfo]) -> String {
 }
 
 fn build_push_preview_bundle(response: &MessageResponse) -> PushPreviewBundle {
-    let mentioned_uids = response
-        .message
-        .as_deref()
-        .map(extract_mention_uids)
-        .unwrap_or_default();
     let rendered_message = response
         .message
         .as_deref()
@@ -581,7 +592,6 @@ fn build_push_preview_bundle(response: &MessageResponse) -> PushPreviewBundle {
             is_deleted,
         },
         body_preview,
-        mentioned_uids,
     }
 }
 
@@ -603,6 +613,34 @@ pub fn build_message_side_effects(
     let ws_msg = std::sync::Arc::new(ServerWsMessage::Message(response.clone()));
 
     let is_system_message = matches!(response.message_type, MessageType::System);
+    let member_set: std::collections::HashSet<i32> = member_uids.iter().copied().collect();
+    // Persisted mention rows and the push job's mention list must agree: both are
+    // member-filtered and exclude the sender. Derive the list once.
+    let mentioned_member_uids: Vec<i32> = if is_system_message {
+        Vec::new()
+    } else {
+        response
+            .message
+            .as_deref()
+            .map(extract_mention_uids)
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|uid| *uid != sender_uid && member_set.contains(uid))
+            .collect()
+    };
+    // A reply to someone's message rides the mention pipeline as a kind='reply'
+    // row. Apply the same filters as mentions (member, not the sender); replying
+    // to a system message notifies no one.
+    let reply_target_uid: Option<i32> = if is_system_message {
+        None
+    } else {
+        response
+            .reply_to_message
+            .as_ref()
+            .filter(|target| !matches!(target.message_type, MessageType::System))
+            .map(|target| target.sender.uid)
+            .filter(|uid| *uid != sender_uid && member_set.contains(uid))
+    };
     let push_job = if enqueue_push && !is_system_message {
         let sender_username =
             load_username_by_uid(conn, sender_uid)?.unwrap_or_else(|| "Someone".to_string());
@@ -621,20 +659,91 @@ pub fn build_message_side_effects(
             body_preview: push_preview.body_preview,
             message_id: response.id,
             thread_root_id: response.reply_root_id,
-            mentioned_uids: push_preview.mentioned_uids,
-            reply_target_uid: response
-                .reply_to_message
-                .as_ref()
-                .map(|message| message.sender.uid),
+            mentioned_uids: mentioned_member_uids.clone(),
+            reply_target_uid,
         })
     } else {
         None
     };
 
+    // Persist @mentions and direct a `Notification` realtime event to each
+    // mentioned member. A reply to someone's message is persisted as a
+    // kind='reply' row and notified the same way; when a message both mentions
+    // and replies to the same person, only the mention row/event is produced.
+    let reply_notification_uid =
+        reply_target_uid.filter(|uid| !mentioned_member_uids.contains(uid));
+    let mut mention_rows: Vec<MessageMention> = mentioned_member_uids
+        .iter()
+        .map(|uid| MessageMention {
+            message_id: response.id,
+            mentioned_uid: *uid,
+            chat_id,
+            thread_root_id: response.reply_root_id,
+            created_at: response.created_at,
+            kind: MentionKind::Mention,
+        })
+        .collect();
+    if let Some(uid) = reply_notification_uid {
+        mention_rows.push(MessageMention {
+            message_id: response.id,
+            mentioned_uid: uid,
+            chat_id,
+            thread_root_id: response.reply_root_id,
+            created_at: response.created_at,
+            kind: MentionKind::Reply,
+        });
+    }
+    if !mention_rows.is_empty() {
+        diesel::insert_into(message_mentions::table)
+            .values(&mention_rows)
+            .on_conflict_do_nothing()
+            .execute(conn)?;
+    }
+
+    let mut notifications: Vec<(i32, std::sync::Arc<ServerWsMessage>)> = Vec::new();
+    if !mentioned_member_uids.is_empty() || reply_notification_uid.is_some() {
+        // Reuse the push job's username when available so the same send only
+        // looks the sender's name up once.
+        let actor_name = if let Some(job) = &push_job {
+            job.sender_username.clone()
+        } else {
+            load_username_by_uid(conn, sender_uid)?.unwrap_or_else(|| "Someone".to_string())
+        };
+        if !mentioned_member_uids.is_empty() {
+            let payload = NotificationPayload {
+                notification_type: NotificationType::Mention,
+                chat_id,
+                message_id: response.id,
+                thread_root_id: response.reply_root_id,
+                actor_uid: sender_uid,
+                actor_name: Some(actor_name.clone()),
+            };
+            let notification = std::sync::Arc::new(ServerWsMessage::Notification(payload));
+            for uid in &mentioned_member_uids {
+                notifications.push((*uid, notification.clone()));
+            }
+        }
+        if let Some(uid) = reply_notification_uid {
+            let payload = NotificationPayload {
+                notification_type: NotificationType::Reply,
+                chat_id,
+                message_id: response.id,
+                thread_root_id: response.reply_root_id,
+                actor_uid: sender_uid,
+                actor_name: Some(actor_name),
+            };
+            notifications.push((
+                uid,
+                std::sync::Arc::new(ServerWsMessage::Notification(payload)),
+            ));
+        }
+    }
+
     Ok(PendingSideEffects {
         ws_msg,
         broadcast_uids: member_uids,
         push_job,
+        notifications,
         unread_event: response
             .reply_root_id
             .is_none()
@@ -644,6 +753,124 @@ pub fn build_message_side_effects(
                 countable: true,
             }),
     })
+}
+
+/// Sync `message_mentions` rows with an edited message body.
+///
+/// Removes rows for mention targets dropped by the edit and inserts rows for
+/// newly mentioned members (member-filtered, excluding the editor), mirroring
+/// `build_message_side_effects`. Newly mentioned members of a thread reply are
+/// auto-subscribed. Returns the uids of newly mentioned members so the caller
+/// can notify them post-commit. `message` must be the pre-edit row (the old
+/// body is diffed against `new_text`).
+///
+/// Reply rows (kind='reply') are never deleted by this diff: dropping an
+/// @mention on the message's reply target downgrades their row back to
+/// 'reply', and adding an @mention over an existing reply row upgrades it to
+/// 'mention'.
+pub fn sync_edited_message_mentions(
+    conn: &mut PgConnection,
+    message: &Message,
+    new_text: &str,
+    editor_uid: i32,
+    edited_at: DateTime<Utc>,
+) -> Result<Vec<i32>, AppError> {
+    let old_uids: std::collections::HashSet<i32> = message
+        .message
+        .as_deref()
+        .map(extract_mention_uids)
+        .unwrap_or_default()
+        .into_iter()
+        .collect();
+    let new_uids: std::collections::HashSet<i32> =
+        extract_mention_uids(new_text).into_iter().collect();
+
+    let removed: Vec<i32> = old_uids.difference(&new_uids).copied().collect();
+    if !removed.is_empty() {
+        use crate::schema::message_mentions::dsl as mm_dsl;
+        let reply_target_uid: Option<i32> = match message.reply_to_id {
+            Some(reply_to_id) => messages_schema::table
+                .filter(messages_schema::id.eq(reply_to_id))
+                .select(messages_schema::sender_uid)
+                .first::<i32>(conn)
+                .optional()?,
+            None => None,
+        };
+        let (keep_reply, drop_mentions): (Vec<i32>, Vec<i32>) = removed
+            .into_iter()
+            .partition(|uid| Some(*uid) == reply_target_uid);
+        if !keep_reply.is_empty() {
+            diesel::update(
+                mm_dsl::message_mentions
+                    .filter(mm_dsl::message_id.eq(message.id))
+                    .filter(mm_dsl::mentioned_uid.eq_any(&keep_reply)),
+            )
+            .set(mm_dsl::kind.eq(MentionKind::Reply))
+            .execute(conn)?;
+        }
+        if !drop_mentions.is_empty() {
+            diesel::delete(
+                mm_dsl::message_mentions
+                    .filter(mm_dsl::message_id.eq(message.id))
+                    .filter(mm_dsl::mentioned_uid.eq_any(&drop_mentions)),
+            )
+            .execute(conn)?;
+        }
+    }
+
+    let added: Vec<i32> = new_uids.difference(&old_uids).copied().collect();
+    if added.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let member_uids: Vec<i32> = group_membership::table
+        .filter(group_membership::chat_id.eq(message.chat_id))
+        .select(group_membership::uid)
+        .load(conn)?;
+    let member_set: std::collections::HashSet<i32> = member_uids.into_iter().collect();
+    let added_members: Vec<i32> = added
+        .into_iter()
+        .filter(|uid| *uid != editor_uid && member_set.contains(uid))
+        .collect();
+    if added_members.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mention_rows: Vec<MessageMention> = added_members
+        .iter()
+        .map(|uid| MessageMention {
+            message_id: message.id,
+            mentioned_uid: *uid,
+            chat_id: message.chat_id,
+            thread_root_id: message.reply_root_id,
+            created_at: edited_at,
+            kind: MentionKind::Mention,
+        })
+        .collect();
+    diesel::insert_into(message_mentions::table)
+        .values(&mention_rows)
+        // A row can already exist when the message replies to the newly
+        // mentioned member (kind='reply'); the explicit @mention wins.
+        .on_conflict((
+            message_mentions::message_id,
+            message_mentions::mentioned_uid,
+        ))
+        .do_update()
+        .set(message_mentions::kind.eq(MentionKind::Mention))
+        .execute(conn)?;
+
+    if let Some(thread_root_id) = message.reply_root_id {
+        for uid in &added_members {
+            crate::services::threads::ensure_thread_subscription(
+                conn,
+                message.chat_id,
+                thread_root_id,
+                *uid,
+            )?;
+        }
+    }
+
+    Ok(added_members)
 }
 
 /// Maximum attachments a single message may carry.
@@ -1018,6 +1245,7 @@ pub async fn send_prepared_message(
                 ws_msg: std::sync::Arc::new(ServerWsMessage::Message(response.clone())),
                 broadcast_uids: Vec::new(),
                 push_job: None,
+                notifications: Vec::new(),
                 unread_event: prepared.reply_root_id.is_none().then_some(
                     TopLevelUnreadCacheEvent {
                         chat_id: prepared.chat_id,
@@ -2076,5 +2304,121 @@ mod tests {
             )),
             StatusCode::FORBIDDEN
         );
+    }
+
+    /// Edit-sync is kind-aware: dropping an @mention on the message's reply
+    /// target downgrades their row to kind='reply' instead of deleting it, an
+    /// unrelated dropped mention is still deleted, and adding an @mention over
+    /// an existing reply row upgrades it to kind='mention'. Requires a test
+    /// database (`WETTY_TEST_DATABASE_URL`); skipped otherwise.
+    #[test]
+    fn sync_edited_message_mentions_preserves_reply_rows() {
+        use crate::models::MentionKind;
+        use crate::schema::message_mentions;
+        use crate::schema::messages as messages_schema;
+        use diesel::prelude::*;
+        use std::sync::atomic::{AtomicI64, Ordering};
+
+        let url = match std::env::var("WETTY_TEST_DATABASE_URL") {
+            Ok(u) => u,
+            Err(_) => {
+                eprintln!("skipping (WETTY_TEST_DATABASE_URL unset)");
+                return;
+            }
+        };
+        let mut conn = diesel::PgConnection::establish(&url).expect("connect to test database");
+
+        static SEQ: AtomicI64 = AtomicI64::new(9_876_576_000);
+        let chat_id = SEQ.fetch_add(1, Ordering::SeqCst);
+        let target_msg = SEQ.fetch_add(1, Ordering::SeqCst);
+        let reply_msg = SEQ.fetch_add(1, Ordering::SeqCst);
+        let editor: i32 = 4245;
+        let target_author: i32 = 4246;
+        let other_mentioned: i32 = 4247;
+
+        let result = conn.transaction::<(), AppError, _>(|conn| {
+            diesel::sql_query("INSERT INTO groups (id, name) VALUES ($1, 'edit-sync-test')")
+                .bind::<diesel::sql_types::BigInt, _>(chat_id)
+                .execute(conn)?;
+            for uid in [editor, target_author, other_mentioned] {
+                diesel::sql_query("INSERT INTO group_membership (chat_id, uid) VALUES ($1, $2)")
+                    .bind::<diesel::sql_types::BigInt, _>(chat_id)
+                    .bind::<diesel::sql_types::Integer, _>(uid)
+                    .execute(conn)?;
+            }
+            // The reply target's author is `target_author`.
+            diesel::sql_query(
+                "INSERT INTO messages (id, message_type, client_generated_id, sender_uid, chat_id, created_at) \
+                 VALUES ($1, 'text', $2, $3, $4, NOW())",
+            )
+            .bind::<diesel::sql_types::BigInt, _>(target_msg)
+            .bind::<diesel::sql_types::Text, _>(format!("cg-{chat_id}-{target_msg}"))
+            .bind::<diesel::sql_types::Integer, _>(target_author)
+            .bind::<diesel::sql_types::BigInt, _>(chat_id)
+            .execute(conn)?;
+            diesel::sql_query(
+                "INSERT INTO messages (id, message_type, client_generated_id, sender_uid, chat_id, reply_to_id, message, created_at) \
+                 VALUES ($1, 'text', $2, $3, $4, $5, $6, NOW())",
+            )
+            .bind::<diesel::sql_types::BigInt, _>(reply_msg)
+            .bind::<diesel::sql_types::Text, _>(format!("cg-{chat_id}-{reply_msg}"))
+            .bind::<diesel::sql_types::Integer, _>(editor)
+            .bind::<diesel::sql_types::BigInt, _>(chat_id)
+            .bind::<diesel::sql_types::BigInt, _>(target_msg)
+            .bind::<diesel::sql_types::Text, _>(
+                format!("hello @[uid:{target_author}] @[uid:{other_mentioned}]"),
+            )
+            .execute(conn)?;
+            for uid in [target_author, other_mentioned] {
+                diesel::sql_query(
+                    "INSERT INTO message_mentions (message_id, mentioned_uid, chat_id, thread_root_id, created_at, kind) \
+                     VALUES ($1, $2, $3, NULL, NOW(), 'mention')",
+                )
+                .bind::<diesel::sql_types::BigInt, _>(reply_msg)
+                .bind::<diesel::sql_types::Integer, _>(uid)
+                .bind::<diesel::sql_types::BigInt, _>(chat_id)
+                .execute(conn)?;
+            }
+
+            let mut message: Message = messages_schema::table
+                .filter(messages_schema::id.eq(reply_msg))
+                .first(conn)?;
+
+            // Edit 1: drop both @mentions. The reply target keeps a downgraded
+            // row; the unrelated mention is deleted.
+            crate::services::messages::sync_edited_message_mentions(
+                conn,
+                &message,
+                "hello there",
+                editor,
+                Utc::now(),
+            )?;
+            let kinds: Vec<MentionKind> = message_mentions::table
+                .filter(message_mentions::message_id.eq(reply_msg))
+                .select(message_mentions::kind)
+                .load(conn)?;
+            assert_eq!(kinds, vec![MentionKind::Reply]);
+
+            // Edit 2: re-add the reply target as an @mention. The reply row is
+            // upgraded to kind='mention' (mention wins).
+            message.message = Some("hello there".to_string());
+            let added = crate::services::messages::sync_edited_message_mentions(
+                conn,
+                &message,
+                "hello there @[uid:4246]",
+                editor,
+                Utc::now(),
+            )?;
+            assert_eq!(added, vec![target_author]);
+            let kinds: Vec<MentionKind> = message_mentions::table
+                .filter(message_mentions::message_id.eq(reply_msg))
+                .select(message_mentions::kind)
+                .load(conn)?;
+            assert_eq!(kinds, vec![MentionKind::Mention]);
+
+            Err(AppError::Internal("rollback"))
+        });
+
+        assert!(result.is_err(), "transaction should roll back");
     }
 }

--- a/backend/src/services/push/mod.rs
+++ b/backend/src/services/push/mod.rs
@@ -151,8 +151,9 @@ mod tests {
         DeliveryFailureAction,
     };
     use super::payload::{
-        build_apns_notification, build_push_payload, format_push_body, truncate_preview,
-        APNS_BODY_LOC_KEY_AUDIO, APNS_BODY_LOC_KEY_INVITE, APNS_BODY_LOC_KEY_NO_PREVIEW,
+        build_apns_notification, build_push_payload, format_push_body, format_reply_push_body,
+        truncate_preview, PushPayloadType, APNS_BODY_LOC_KEY_AUDIO, APNS_BODY_LOC_KEY_INVITE,
+        APNS_BODY_LOC_KEY_MENTION, APNS_BODY_LOC_KEY_NO_PREVIEW, APNS_BODY_LOC_KEY_REPLY,
         APNS_BODY_LOC_KEY_STICKER_EMOJI, APNS_BODY_LOC_KEY_WITH_PREVIEW, APNS_TITLE_LOC_KEY,
         MESSAGE_PREVIEW_MAX,
     };
@@ -214,7 +215,7 @@ mod tests {
             reply_target_uid: None,
         };
 
-        let payload = build_push_payload(&job, 3, "alice: [Sticker] 🙂");
+        let payload = build_push_payload(&job, 3, "alice: [Sticker] 🙂", 42);
         assert_eq!(payload.sender_name, "alice");
         assert_eq!(payload.body, "alice: [Sticker] 🙂");
         assert_eq!(payload.message_preview.message_type, MessageType::Sticker);
@@ -239,6 +240,182 @@ mod tests {
     }
 
     #[test]
+    fn build_push_payload_marks_mention_for_mentioned_recipient() {
+        let job = PushJob {
+            chat_id: 10,
+            sender_uid: 7,
+            sender_username: "alice".to_string(),
+            chat_name: "General".to_string(),
+            message_preview: PushMessagePreview {
+                message: Some("hi @[uid:42]".to_string()),
+                message_type: MessageType::Text,
+                sticker: None,
+                attachments: Vec::new(),
+                is_deleted: false,
+            },
+            body_preview: Some("hi @you".to_string()),
+            message_id: 99,
+            thread_root_id: None,
+            mentioned_uids: vec![42],
+            reply_target_uid: None,
+        };
+
+        // Mentioned recipient -> typed as Mention with context.
+        let mentioned = build_push_payload(&job, 1, "alice: hi @you", 42);
+        assert_eq!(mentioned.type_, PushPayloadType::Mention);
+        assert_eq!(mentioned.mentioned_uid, Some(42));
+        let serialized = serde_json::to_value(&mentioned).expect("serialize");
+        assert_eq!(serialized["type"], "mention");
+        assert_eq!(serialized["mentionedUid"], 42);
+
+        // Non-mentioned recipient -> generic newMessage, no mention context.
+        let other = build_push_payload(&job, 1, "alice: hi @you", 99);
+        assert_eq!(other.type_, PushPayloadType::NewMessage);
+        assert_eq!(other.mentioned_uid, None);
+        let other_serialized = serde_json::to_value(&other).expect("serialize");
+        assert!(other_serialized.get("mentionedUid").is_none());
+    }
+
+    #[test]
+    fn build_apns_notification_uses_mention_loc_key_for_mentioned_recipient() {
+        let job = PushJob {
+            chat_id: 10,
+            sender_uid: 7,
+            sender_username: "alice".to_string(),
+            chat_name: "General".to_string(),
+            message_preview: PushMessagePreview {
+                message: Some("hello there".to_string()),
+                message_type: MessageType::Text,
+                sticker: None,
+                attachments: Vec::new(),
+                is_deleted: false,
+            },
+            body_preview: Some("hello there".to_string()),
+            message_id: 99,
+            thread_root_id: None,
+            mentioned_uids: vec![42],
+            reply_target_uid: None,
+        };
+
+        let n = build_apns_notification(&job, 1, 42);
+        assert_eq!(n.body_loc_key, APNS_BODY_LOC_KEY_MENTION);
+        assert_eq!(
+            n.body_loc_args,
+            vec!["alice".to_string(), "hello there".to_string()]
+        );
+        assert_eq!(n.custom_data.type_, PushPayloadType::Mention);
+        assert_eq!(n.custom_data.mentioned_uid, Some(42));
+
+        // Non-mentioned recipient falls back to the standard text-with-preview key.
+        let other = build_apns_notification(&job, 1, 99);
+        assert_eq!(other.body_loc_key, APNS_BODY_LOC_KEY_WITH_PREVIEW);
+        assert_eq!(other.custom_data.type_, PushPayloadType::NewMessage);
+        assert_eq!(other.custom_data.mentioned_uid, None);
+    }
+
+    #[test]
+    fn build_push_payload_types_reply_for_reply_target() {
+        let job = PushJob {
+            chat_id: 10,
+            sender_uid: 7,
+            sender_username: "alice".to_string(),
+            chat_name: "General".to_string(),
+            message_preview: PushMessagePreview {
+                message: Some("a reply".to_string()),
+                message_type: MessageType::Text,
+                sticker: None,
+                attachments: Vec::new(),
+                is_deleted: false,
+            },
+            body_preview: Some("a reply".to_string()),
+            message_id: 99,
+            thread_root_id: Some(55),
+            mentioned_uids: Vec::new(),
+            reply_target_uid: Some(42),
+        };
+
+        let reply = build_push_payload(&job, 1, "alice replied to your message: a reply", 42);
+        assert_eq!(reply.type_, PushPayloadType::Reply);
+        assert_eq!(reply.mentioned_uid, None);
+        let serialized = serde_json::to_value(&reply).expect("serialize");
+        assert_eq!(serialized["type"], "reply");
+        assert!(serialized.get("mentionedUid").is_none());
+
+        // Unrelated recipient stays generic.
+        let other = build_push_payload(&job, 1, "alice: a reply", 99);
+        assert_eq!(other.type_, PushPayloadType::NewMessage);
+    }
+
+    #[test]
+    fn build_push_payload_mention_outranks_reply_for_same_recipient() {
+        let job = PushJob {
+            chat_id: 10,
+            sender_uid: 7,
+            sender_username: "alice".to_string(),
+            chat_name: "General".to_string(),
+            message_preview: PushMessagePreview {
+                message: Some("hi @[uid:42]".to_string()),
+                message_type: MessageType::Text,
+                sticker: None,
+                attachments: Vec::new(),
+                is_deleted: false,
+            },
+            body_preview: Some("hi @you".to_string()),
+            message_id: 99,
+            thread_root_id: None,
+            mentioned_uids: vec![42],
+            reply_target_uid: Some(42),
+        };
+
+        let payload = build_push_payload(&job, 1, "alice: hi @you", 42);
+        assert_eq!(payload.type_, PushPayloadType::Mention);
+        assert_eq!(payload.mentioned_uid, Some(42));
+    }
+
+    #[test]
+    fn build_apns_notification_uses_reply_loc_key_for_reply_target() {
+        let job = PushJob {
+            chat_id: 10,
+            sender_uid: 7,
+            sender_username: "alice".to_string(),
+            chat_name: "General".to_string(),
+            message_preview: PushMessagePreview {
+                message: Some("a reply".to_string()),
+                message_type: MessageType::Text,
+                sticker: None,
+                attachments: Vec::new(),
+                is_deleted: false,
+            },
+            body_preview: Some("a reply".to_string()),
+            message_id: 99,
+            thread_root_id: None,
+            mentioned_uids: Vec::new(),
+            reply_target_uid: Some(42),
+        };
+
+        let n = build_apns_notification(&job, 1, 42);
+        assert_eq!(n.body_loc_key, APNS_BODY_LOC_KEY_REPLY);
+        assert_eq!(
+            n.body_loc_args,
+            vec!["alice".to_string(), "a reply".to_string()]
+        );
+        assert_eq!(n.custom_data.type_, PushPayloadType::Reply);
+        assert_eq!(n.custom_data.mentioned_uid, None);
+    }
+
+    #[test]
+    fn format_reply_push_body_uses_reply_copy() {
+        assert_eq!(
+            format_reply_push_body("alice", Some("a reply")),
+            "alice replied to your message: a reply"
+        );
+        assert_eq!(
+            format_reply_push_body("alice", None),
+            "alice replied to your message"
+        );
+    }
+
+    #[test]
     fn build_apns_notification_uses_localized_keys_and_custom_data() {
         let job = PushJob {
             chat_id: 10,
@@ -259,7 +436,7 @@ mod tests {
             reply_target_uid: None,
         };
 
-        let n = build_apns_notification(&job, 7);
+        let n = build_apns_notification(&job, 7, 42);
         assert_eq!(n.title_loc_key, APNS_TITLE_LOC_KEY);
         assert_eq!(n.title_loc_args, vec!["General".to_string()]);
         assert_eq!(n.body_loc_key, APNS_BODY_LOC_KEY_WITH_PREVIEW);
@@ -295,7 +472,7 @@ mod tests {
             reply_target_uid: None,
         };
 
-        let payload = build_apns_notification(&job, 0);
+        let payload = build_apns_notification(&job, 0, 42);
         assert_eq!(payload.body_loc_key, APNS_BODY_LOC_KEY_NO_PREVIEW);
         assert_eq!(payload.body_loc_args, vec!["alice".to_string()]);
         assert_eq!(payload.badge, 0);
@@ -323,7 +500,7 @@ mod tests {
             reply_target_uid: None,
         };
 
-        let n = build_apns_notification(&job, 2);
+        let n = build_apns_notification(&job, 2, 42);
         assert_eq!(n.body_loc_key, APNS_BODY_LOC_KEY_AUDIO);
         assert_eq!(n.body_loc_args, vec!["bob".to_string()]);
     }
@@ -351,7 +528,7 @@ mod tests {
             reply_target_uid: None,
         };
 
-        let n = build_apns_notification(&job, 0);
+        let n = build_apns_notification(&job, 0, 42);
         assert_eq!(n.body_loc_key, APNS_BODY_LOC_KEY_STICKER_EMOJI);
         assert_eq!(n.body_loc_args, vec!["bob".to_string(), "🎉".to_string()]);
     }
@@ -379,7 +556,7 @@ mod tests {
             reply_target_uid: None,
         };
 
-        let n = build_apns_notification(&job, 1);
+        let n = build_apns_notification(&job, 1, 42);
         assert_eq!(n.body_loc_key, "push.message.body.image");
         assert_eq!(n.body_loc_args, vec!["bob".to_string()]);
     }
@@ -407,7 +584,7 @@ mod tests {
             reply_target_uid: None,
         };
 
-        let n = build_apns_notification(&job, 0);
+        let n = build_apns_notification(&job, 0, 42);
         assert_eq!(n.body_loc_key, "push.message.body.attachment.with_preview");
         assert_eq!(
             n.body_loc_args,
@@ -438,7 +615,7 @@ mod tests {
             reply_target_uid: None,
         };
 
-        let n = build_apns_notification(&job, 0);
+        let n = build_apns_notification(&job, 0, 42);
         assert_eq!(n.body_loc_key, "push.message.body.video");
     }
 
@@ -465,7 +642,7 @@ mod tests {
             reply_target_uid: None,
         };
 
-        let n = build_apns_notification(&job, 0);
+        let n = build_apns_notification(&job, 0, 42);
         assert_eq!(n.body_loc_key, "push.message.body.attachment");
         assert_eq!(n.body_loc_args, vec!["bob".to_string()]);
     }
@@ -491,7 +668,7 @@ mod tests {
             reply_target_uid: None,
         };
 
-        let n = build_apns_notification(&job, 0);
+        let n = build_apns_notification(&job, 0, 42);
         assert_eq!(n.body_loc_key, APNS_BODY_LOC_KEY_INVITE);
         assert_eq!(n.body_loc_args, vec!["bob".to_string()]);
     }

--- a/backend/src/services/push/payload.rs
+++ b/backend/src/services/push/payload.rs
@@ -22,12 +22,28 @@ pub(super) const APNS_BODY_LOC_KEY_INVITE: &str = "push.message.body.invite";
 const APNS_BODY_LOC_KEY_ATTACHMENT: &str = "push.message.body.attachment";
 const APNS_BODY_LOC_KEY_ATTACHMENT_WITH_PREVIEW: &str = "push.message.body.attachment.with_preview";
 const APNS_BODY_LOC_KEY_DELETED: &str = "push.message.body.deleted";
+pub(super) const APNS_BODY_LOC_KEY_MENTION: &str = "push.mention.body";
+pub(super) const APNS_BODY_LOC_KEY_REPLY: &str = "push.reply.body";
 
 /// A push notification job enqueued when a new message is created.
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub(super) enum PushPayloadType {
     NewMessage,
+    Mention,
+    Reply,
+}
+
+/// Per-recipient payload kind. A mention outranks a reply when the same
+/// message both mentions and replies to the recipient.
+pub(super) fn payload_type_for(job: &PushJob, recipient_uid: i32) -> PushPayloadType {
+    if job.mentioned_uids.contains(&recipient_uid) {
+        PushPayloadType::Mention
+    } else if job.reply_target_uid == Some(recipient_uid) {
+        PushPayloadType::Reply
+    } else {
+        PushPayloadType::NewMessage
+    }
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -66,6 +82,8 @@ pub(super) struct PushPayload {
     pub(super) sender_name: String,
     pub(super) message_preview: PushMessagePreview,
     pub(super) unread_count: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) mentioned_uid: Option<i32>,
     pub(super) data: PushPayloadData,
 }
 
@@ -81,6 +99,8 @@ pub(super) struct ApnsCustomData {
     pub(super) sender_name: String,
     pub(super) message_preview: PushMessagePreview,
     pub(super) unread_count: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) mentioned_uid: Option<i32>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -94,14 +114,21 @@ pub(super) struct ApnsNotification {
     pub(super) custom_data: ApnsCustomData,
 }
 
-pub(super) fn build_push_payload(job: &PushJob, unread_count: i64, body_text: &str) -> PushPayload {
+pub(super) fn build_push_payload(
+    job: &PushJob,
+    unread_count: i64,
+    body_text: &str,
+    recipient_uid: i32,
+) -> PushPayload {
+    let is_mention = job.mentioned_uids.contains(&recipient_uid);
     PushPayload {
-        type_: PushPayloadType::NewMessage,
+        type_: payload_type_for(job, recipient_uid),
         title: job.chat_name.clone(),
         body: body_text.to_string(),
         sender_name: job.sender_username.clone(),
         message_preview: job.message_preview.clone(),
         unread_count,
+        mentioned_uid: is_mention.then_some(recipient_uid),
         data: PushPayloadData {
             chat_id: job.chat_id.to_string(),
             message_id: job.message_id.to_string(),
@@ -110,11 +137,33 @@ pub(super) fn build_push_payload(job: &PushJob, unread_count: i64, body_text: &s
     }
 }
 
-pub(super) fn build_apns_notification(job: &PushJob, unread_count: i64) -> ApnsNotification {
+pub(super) fn build_apns_notification(
+    job: &PushJob,
+    unread_count: i64,
+    recipient_uid: i32,
+) -> ApnsNotification {
     let badge = unread_count.clamp(0, u32::MAX as i64) as u32;
     let preview = &job.message_preview;
+    let is_mention = job.mentioned_uids.contains(&recipient_uid);
+    let payload_type = payload_type_for(job, recipient_uid);
+    let is_reply = matches!(payload_type, PushPayloadType::Reply);
 
-    let (body_loc_key, body_loc_args) = if preview.is_deleted {
+    let (body_loc_key, body_loc_args) = if is_mention {
+        // Mentions only occur on text messages; surface a dedicated localized body.
+        let text = preview.message.as_deref().unwrap_or("");
+        (
+            APNS_BODY_LOC_KEY_MENTION,
+            vec![job.sender_username.clone(), truncate_preview(text)],
+        )
+    } else if is_reply {
+        // Reply targets get a mention-style body: sender name + the reply's
+        // preview text (empty when the reply is a media-only message).
+        let text = preview.message.as_deref().unwrap_or("");
+        (
+            APNS_BODY_LOC_KEY_REPLY,
+            vec![job.sender_username.clone(), truncate_preview(text)],
+        )
+    } else if preview.is_deleted {
         (APNS_BODY_LOC_KEY_DELETED, vec![job.sender_username.clone()])
     } else {
         match preview.message_type {
@@ -179,13 +228,14 @@ pub(super) fn build_apns_notification(job: &PushJob, unread_count: i64) -> ApnsN
         badge,
         thread_id,
         custom_data: ApnsCustomData {
-            type_: PushPayloadType::NewMessage,
+            type_: payload_type,
             chat_id: job.chat_id.to_string(),
             message_id: job.message_id.to_string(),
             thread_root_id: job.thread_root_id.map(|id| id.to_string()),
             sender_name: job.sender_username.clone(),
             message_preview: job.message_preview.clone(),
             unread_count,
+            mentioned_uid: is_mention.then_some(recipient_uid),
         },
     }
 }
@@ -207,6 +257,17 @@ pub(super) fn format_push_body(sender_username: &str, preview: Option<&str>) -> 
     match preview {
         Some(preview) => format!("{}: {}", sender_username, truncate_preview(preview)),
         None => format!("{} sent a message", sender_username),
+    }
+}
+
+pub(super) fn format_reply_push_body(sender_username: &str, preview: Option<&str>) -> String {
+    match preview {
+        Some(preview) => format!(
+            "{} replied to your message: {}",
+            sender_username,
+            truncate_preview(preview)
+        ),
+        None => format!("{} replied to your message", sender_username),
     }
 }
 

--- a/backend/src/services/push/policy.rs
+++ b/backend/src/services/push/policy.rs
@@ -23,6 +23,9 @@ pub struct PushRecipientContext {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PushDecision {
     Send,
+    /// One-off push to a directly addressed recipient (mentioned, or the
+    /// target of a reply) who is not otherwise eligible — e.g. thread without
+    /// an active subscription. Treated like [`PushDecision::Send`] downstream.
     SendOneOffMention,
     Skip(PushSkipReason),
 }
@@ -66,14 +69,14 @@ pub fn should_send_push(recipient: &PushRecipientContext, now: DateTime<Utc>) ->
         }
         ThreadPushState::ActiveSubscription => PushDecision::Send,
         ThreadPushState::ArchivedSubscription => {
-            if recipient.is_mentioned {
+            if recipient.is_mentioned || recipient.is_reply_target {
                 PushDecision::SendOneOffMention
             } else {
                 PushDecision::Skip(PushSkipReason::ThreadArchived)
             }
         }
         ThreadPushState::NoSubscription => {
-            if recipient.is_mentioned {
+            if recipient.is_mentioned || recipient.is_reply_target {
                 PushDecision::SendOneOffMention
             } else {
                 PushDecision::Skip(PushSkipReason::NoThreadSubscription)
@@ -207,6 +210,26 @@ mod tests {
     fn no_thread_subscription_mention_gets_one_off_push() {
         let (now, mut recipient) = base(ThreadPushState::NoSubscription);
         recipient.is_mentioned = true;
+        assert_eq!(
+            should_send_push(&recipient, now),
+            PushDecision::SendOneOffMention
+        );
+    }
+
+    #[test]
+    fn archived_thread_subscription_reply_target_gets_one_off_push() {
+        let (now, mut recipient) = base(ThreadPushState::ArchivedSubscription);
+        recipient.is_reply_target = true;
+        assert_eq!(
+            should_send_push(&recipient, now),
+            PushDecision::SendOneOffMention
+        );
+    }
+
+    #[test]
+    fn no_thread_subscription_reply_target_gets_one_off_push() {
+        let (now, mut recipient) = base(ThreadPushState::NoSubscription);
+        recipient.is_reply_target = true;
         assert_eq!(
             should_send_push(&recipient, now),
             PushDecision::SendOneOffMention

--- a/backend/src/services/push/worker.rs
+++ b/backend/src/services/push/worker.rs
@@ -13,7 +13,10 @@ use crate::schema::push_subscriptions;
 use crate::services::ws_registry::ConnectionRegistry;
 
 use super::delivery::{DeliveryFailure, DeliveryFailureAction};
-use super::payload::{build_apns_notification, build_push_payload, format_push_body};
+use super::payload::{
+    build_apns_notification, build_push_payload, format_push_body, format_reply_push_body,
+    payload_type_for, PushPayloadType,
+};
 use super::policy::{
     should_send_push, PushDecision, PushRecipientContext, PushSkipReason, ThreadPushState,
 };
@@ -315,18 +318,26 @@ async fn process_push_job(
             std::collections::HashMap::new()
         });
 
-    // 4. Build the push payload base text.
-    let body_text = format_push_body(&job.sender_username, job.body_preview.as_deref());
-
-    // 5. Send concurrently with bounded parallelism.
+    // 4. Send concurrently with bounded parallelism.
     let delivery_results: Vec<DeliveryAttemptResult> = stream::iter(subs)
         .map(|sub| {
             let service = service.clone();
 
             let unread = unread_counts.get(&sub.user_id).copied().unwrap_or(0);
-            let web_payload = serde_json::to_vec(&build_push_payload(job, unread, &body_text))
-                .unwrap_or_default();
-            let apns_notification = build_apns_notification(job, unread);
+            // Reply targets get their own body copy; mentions and generic
+            // messages share the standard one.
+            let body_text = match payload_type_for(job, sub.user_id) {
+                PushPayloadType::Reply => {
+                    format_reply_push_body(&job.sender_username, job.body_preview.as_deref())
+                }
+                PushPayloadType::Mention | PushPayloadType::NewMessage => {
+                    format_push_body(&job.sender_username, job.body_preview.as_deref())
+                }
+            };
+            let web_payload =
+                serde_json::to_vec(&build_push_payload(job, unread, &body_text, sub.user_id))
+                    .unwrap_or_default();
+            let apns_notification = build_apns_notification(job, unread, sub.user_id);
 
             async move {
                 match service

--- a/backend/src/services/push/worker.rs
+++ b/backend/src/services/push/worker.rs
@@ -185,18 +185,30 @@ fn load_recipient_candidates(
             );
         }
 
-        if !job.mentioned_uids.is_empty() {
+        if !job.mentioned_uids.is_empty() || job.reply_target_uid.is_some() {
             let rows: Vec<(i32, Option<chrono::DateTime<chrono::Utc>>, bool)> =
                 group_membership::table
                     .filter(gm_dsl::chat_id.eq(job.chat_id))
-                    .filter(gm_dsl::uid.eq_any(&job.mentioned_uids))
+                    .filter(
+                        gm_dsl::uid.eq_any(
+                            job.mentioned_uids
+                                .iter()
+                                .copied()
+                                .chain(job.reply_target_uid),
+                        ),
+                    )
                     .select((
                         group_membership::uid,
                         group_membership::muted_until,
                         group_membership::archived,
                     ))
                     .load(conn)
-                    .map_err(|e| format!("Failed to load mentioned member candidates: {:?}", e))?;
+                    .map_err(|e| {
+                        format!(
+                            "Failed to load directly addressed member candidates: {:?}",
+                            e
+                        )
+                    })?;
 
             for (uid, muted_until, chat_archived) in rows {
                 candidates.entry(uid).or_insert(RecipientCandidate {

--- a/backend/src/services/threads.rs
+++ b/backend/src/services/threads.rs
@@ -219,6 +219,17 @@ pub fn mark_thread_as_read(
     )
     .set(thread_user_states::last_read_message_id.eq(Some(message_id)))
     .execute(conn)?;
+    // Advancing the read position also acknowledges unread reactions: they are
+    // derived from a reaction-timestamp cursor (see UnreadService), which only
+    // moves forward.
+    diesel::update(
+        thread_user_states::table
+            .filter(thread_user_states::chat_id.eq(chat_id))
+            .filter(thread_user_states::thread_root_id.eq(thread_root_id))
+            .filter(thread_user_states::uid.eq(uid)),
+    )
+    .set(thread_user_states::last_reactions_read_at.eq(Utc::now()))
+    .execute(conn)?;
     Ok(updated > 0)
 }
 
@@ -724,6 +735,75 @@ pub fn enrich_thread_list(
         .map(|r| (r.thread_root_id, r.unread_count))
         .collect();
 
+    // 0b. Batch query: unread @mention counts per thread (for the returned page)
+    #[derive(QueryableByName)]
+    struct UnreadMentionRow {
+        #[diesel(sql_type = diesel::sql_types::BigInt)]
+        thread_root_id: i64,
+        #[diesel(sql_type = diesel::sql_types::BigInt)]
+        mention_count: i64,
+    }
+    let mention_rows: Vec<UnreadMentionRow> = sql_query(
+        "SELECT mm.thread_root_id,
+                COUNT(*)::bigint AS mention_count
+         FROM message_mentions mm
+         JOIN thread_user_states tus
+           ON tus.chat_id = mm.chat_id
+          AND tus.thread_root_id = mm.thread_root_id
+          AND tus.uid = mm.mentioned_uid
+         WHERE mm.mentioned_uid = $1
+           AND mm.thread_root_id = ANY($2)
+           AND mm.message_id > COALESCE(tus.last_read_message_id, 0)
+         GROUP BY mm.thread_root_id",
+    )
+    .bind::<diesel::sql_types::Integer, _>(uid)
+    .bind::<diesel::sql_types::Array<diesel::sql_types::BigInt>, _>(&root_ids)
+    .load(conn)?;
+    let mention_map: HashMap<i64, i64> = mention_rows
+        .into_iter()
+        .map(|r| (r.thread_root_id, r.mention_count.min(MAX_UNREAD_COUNT)))
+        .collect();
+
+    // 0c. Batch query: unread-reaction counts per thread (reactions on the
+    // user's messages in each thread, aggregated per message; cursor is the
+    // per-(thread, user) reaction timestamp). Rows without a thread_user_states
+    // row produce no count, mirroring the mention join semantics.
+    #[derive(QueryableByName)]
+    struct UnreadReactionRow {
+        #[diesel(sql_type = diesel::sql_types::BigInt)]
+        thread_root_id: i64,
+        #[diesel(sql_type = diesel::sql_types::BigInt)]
+        reaction_count: i64,
+    }
+    let reaction_rows: Vec<UnreadReactionRow> = sql_query(
+        "SELECT my_msgs.thread_root_id,
+                COUNT(DISTINCT mr.message_id)::bigint AS reaction_count
+         FROM (
+             SELECT m.id AS message_id, m.chat_id AS chat_id, m.reply_root_id AS thread_root_id, m.sender_uid
+             FROM messages m
+             WHERE m.reply_root_id = ANY($2)
+               AND m.deleted_at IS NULL
+               AND m.is_published = TRUE
+               AND m.sender_uid = $1
+         ) my_msgs
+         JOIN thread_user_states tus
+           ON tus.chat_id = my_msgs.chat_id
+          AND tus.thread_root_id = my_msgs.thread_root_id
+          AND tus.uid = my_msgs.sender_uid
+         JOIN message_reactions mr
+           ON mr.message_id = my_msgs.message_id
+          AND mr.user_uid <> my_msgs.sender_uid
+          AND mr.created_at > tus.last_reactions_read_at
+         GROUP BY my_msgs.thread_root_id",
+    )
+    .bind::<diesel::sql_types::Integer, _>(uid)
+    .bind::<diesel::sql_types::Array<diesel::sql_types::BigInt>, _>(&root_ids)
+    .load(conn)?;
+    let reaction_map: HashMap<i64, i64> = reaction_rows
+        .into_iter()
+        .map(|r| (r.thread_root_id, r.reaction_count.min(MAX_UNREAD_COUNT)))
+        .collect();
+
     // 1. Batch query: distinct participants per thread (replies + root message author)
     let participant_rows: Vec<ParticipantRow> = sql_query(
         "SELECT DISTINCT reply_root_id, sender_uid FROM (
@@ -967,6 +1047,8 @@ pub fn enrich_thread_list(
                 reply_count: row.reply_count,
                 last_reply_at: row.last_reply_at,
                 unread_count: unread_map.get(&row.thread_root_id).copied().unwrap_or(0),
+                unread_mentions: mention_map.get(&row.thread_root_id).copied().unwrap_or(0),
+                unread_reactions: reaction_map.get(&row.thread_root_id).copied().unwrap_or(0),
                 last_read_message_id: row.last_read_message_id,
                 subscribed_at: row.subscribed_at,
                 archived: row.archived,

--- a/backend/src/services/unread/service.rs
+++ b/backend/src/services/unread/service.rs
@@ -64,6 +64,63 @@ struct ChatUnreadSnapshotRow {
     is_counted: bool,
 }
 
+#[derive(diesel::QueryableByName)]
+struct UnreadMentionCountRow {
+    #[diesel(sql_type = diesel::sql_types::BigInt)]
+    chat_id: i64,
+    #[diesel(sql_type = diesel::sql_types::BigInt)]
+    mention_count: i64,
+}
+
+#[derive(diesel::QueryableByName)]
+struct UnreadReactionCountRow {
+    #[diesel(sql_type = diesel::sql_types::BigInt)]
+    chat_id: i64,
+    #[diesel(sql_type = diesel::sql_types::BigInt)]
+    reaction_count: i64,
+}
+
+#[derive(diesel::QueryableByName)]
+struct ReactionTotalRow {
+    #[diesel(sql_type = diesel::sql_types::BigInt)]
+    reaction_count: i64,
+}
+
+/// Shared filter for the unread-reaction queries: reactions on the user's
+/// non-deleted, published messages in one chat, excluding self-reactions.
+/// `$1` = uid, `$2` = chat id.
+const UNREAD_REACTIONS_FILTER: &str = "FROM message_reactions mr
+    JOIN messages m ON m.id = mr.message_id
+    WHERE mr.message_author_uid = $1
+      AND mr.user_uid <> $1
+      AND m.chat_id = $2
+      AND m.deleted_at IS NULL
+      AND m.is_published = TRUE";
+
+/// Main-scope tail (reactions on top-level messages), cursor from the chat
+/// membership row.
+const UNREAD_REACTIONS_MAIN_TAIL: &str = "AND m.reply_root_id IS NULL
+    AND mr.created_at > COALESCE((
+        SELECT gm.last_reactions_read_at
+        FROM group_membership gm
+        WHERE gm.chat_id = $2 AND gm.uid = $1
+    ), '-infinity'::timestamptz)";
+
+/// Thread-scope tail (reactions on the user's messages in thread `$3`),
+/// cursor from the per-thread user state row.
+const UNREAD_REACTIONS_THREAD_TAIL: &str = "AND m.reply_root_id = $3
+    AND mr.created_at > COALESCE((
+        SELECT tus.last_reactions_read_at
+        FROM thread_user_states tus
+        WHERE tus.chat_id = $2 AND tus.thread_root_id = $3 AND tus.uid = $1
+    ), '-infinity'::timestamptz)";
+
+#[derive(diesel::QueryableByName)]
+struct UnreadReactionIdRow {
+    #[diesel(sql_type = diesel::sql_types::BigInt)]
+    message_id: i64,
+}
+
 impl UnreadService {
     pub fn new() -> Self {
         Self::default()
@@ -107,6 +164,216 @@ impl UnreadService {
     ) -> Result<HashMap<i32, i64>, DieselError> {
         let memberships = Self::load_users_chat_memberships(conn, target_uids)?;
         self.count_user_membership_unread_totals(conn, target_uids, &memberships, Utc::now())
+    }
+
+    /// Per-chat unread @mention counts (main scope, non-thread messages) for a user.
+    ///
+    /// Unlike `unread_count`, mention counts deliberately include muted (and archived)
+    /// chats: a mention is a direct call-out that pierces mute and lights the global
+    /// mention badge.
+    pub fn count_user_chat_unread_mentions(
+        &self,
+        conn: &mut PgConnection,
+        uid: i32,
+    ) -> Result<HashMap<i64, i64>, DieselError> {
+        let rows = sql_query(
+            "SELECT mm.chat_id AS chat_id, COUNT(*)::BIGINT AS mention_count
+             FROM message_mentions mm
+             JOIN group_membership gm
+               ON gm.chat_id = mm.chat_id AND gm.uid = mm.mentioned_uid
+             WHERE mm.mentioned_uid = $1
+               AND mm.thread_root_id IS NULL
+               AND mm.message_id > COALESCE(gm.last_read_message_id, 0)
+             GROUP BY mm.chat_id",
+        )
+        .bind::<diesel::sql_types::Integer, _>(uid)
+        .load::<UnreadMentionCountRow>(conn)?;
+        Ok(rows
+            .into_iter()
+            .map(|r| (r.chat_id, r.mention_count.min(MAX_UNREAD_COUNT)))
+            .collect())
+    }
+
+    /// Unread @mention count for a single chat, given the user's read pointer.
+    ///
+    /// `thread_root_id`: `None` counts main-scope mentions (`thread_root_id IS NULL`);
+    /// `Some(id)` counts thread-scope mentions. Mirrors `list_chat_unread_mentions`.
+    /// Used by the per-chat unread endpoint, the chat mark-as-read response, and
+    /// the thread mark-as-read response.
+    pub fn count_chat_unread_mentions(
+        &self,
+        conn: &mut PgConnection,
+        uid: i32,
+        chat_id: i64,
+        last_read_message_id: Option<i64>,
+        thread_root_id: Option<i64>,
+    ) -> Result<i64, DieselError> {
+        use crate::schema::message_mentions::dsl as mm_dsl;
+        let count: i64 = match thread_root_id {
+            Some(thread_id) => mm_dsl::message_mentions
+                .filter(mm_dsl::mentioned_uid.eq(uid))
+                .filter(mm_dsl::chat_id.eq(chat_id))
+                .filter(mm_dsl::thread_root_id.eq(thread_id))
+                .filter(mm_dsl::message_id.gt(last_read_message_id.unwrap_or(0)))
+                .count()
+                .get_result(conn)?,
+            None => mm_dsl::message_mentions
+                .filter(mm_dsl::mentioned_uid.eq(uid))
+                .filter(mm_dsl::chat_id.eq(chat_id))
+                .filter(mm_dsl::thread_root_id.is_null())
+                .filter(mm_dsl::message_id.gt(last_read_message_id.unwrap_or(0)))
+                .count()
+                .get_result(conn)?,
+        };
+        Ok(count.min(MAX_UNREAD_COUNT))
+    }
+
+    /// Unread @mention message ids for a single chat, newest-first.
+    ///
+    /// `thread_root_id`: `None` selects main-scope mentions (`thread_root_id IS NULL`);
+    /// `Some(id)` selects thread-scope mentions. Mirrors `count_chat_unread_mentions`
+    /// but returns ids instead of a count. Served by `message_mentions_unread_idx`.
+    pub fn list_chat_unread_mentions(
+        &self,
+        conn: &mut PgConnection,
+        uid: i32,
+        chat_id: i64,
+        last_read_message_id: Option<i64>,
+        thread_root_id: Option<i64>,
+        limit: i64,
+    ) -> Result<Vec<i64>, DieselError> {
+        use crate::schema::message_mentions::dsl as mm_dsl;
+
+        let read_cursor = last_read_message_id.unwrap_or(0);
+
+        let ids: Vec<i64> = match thread_root_id {
+            Some(thread_id) => mm_dsl::message_mentions
+                .filter(mm_dsl::mentioned_uid.eq(uid))
+                .filter(mm_dsl::chat_id.eq(chat_id))
+                .filter(mm_dsl::thread_root_id.eq(thread_id))
+                .filter(mm_dsl::message_id.gt(read_cursor))
+                .select(mm_dsl::message_id)
+                .order(mm_dsl::message_id.desc())
+                .limit(limit)
+                .load(conn)?,
+            None => mm_dsl::message_mentions
+                .filter(mm_dsl::mentioned_uid.eq(uid))
+                .filter(mm_dsl::chat_id.eq(chat_id))
+                .filter(mm_dsl::thread_root_id.is_null())
+                .filter(mm_dsl::message_id.gt(read_cursor))
+                .select(mm_dsl::message_id)
+                .order(mm_dsl::message_id.desc())
+                .limit(limit)
+                .load(conn)?,
+        };
+
+        Ok(ids)
+    }
+
+    /// Per-chat unread-reaction counts (main scope: reactions on the user's
+    /// top-level messages) for a user, aggregated per message.
+    ///
+    /// Unread reactions are derived from `message_reactions` (no per-row read
+    /// flag): a reaction is unread while `created_at > last_reactions_read_at`.
+    /// Self-reactions never count. Like mentions, this deliberately ignores
+    /// mute/archive; unlike mentions it is NOT folded into the global unread
+    /// message count — it only feeds list badges.
+    pub fn count_user_chat_unread_reactions(
+        &self,
+        conn: &mut PgConnection,
+        uid: i32,
+    ) -> Result<HashMap<i64, i64>, DieselError> {
+        let rows = sql_query(
+            "SELECT m.chat_id AS chat_id, COUNT(DISTINCT mr.message_id)::BIGINT AS reaction_count
+             FROM message_reactions mr
+             JOIN messages m ON m.id = mr.message_id
+             JOIN group_membership gm
+               ON gm.chat_id = m.chat_id AND gm.uid = $1
+             WHERE mr.message_author_uid = $1
+               AND mr.user_uid <> $1
+               AND m.deleted_at IS NULL
+               AND m.is_published = TRUE
+               AND m.reply_root_id IS NULL
+               AND mr.created_at > gm.last_reactions_read_at
+             GROUP BY m.chat_id",
+        )
+        .bind::<diesel::sql_types::Integer, _>(uid)
+        .load::<UnreadReactionCountRow>(conn)?;
+        Ok(rows
+            .into_iter()
+            .map(|r| (r.chat_id, r.reaction_count.min(MAX_UNREAD_COUNT)))
+            .collect())
+    }
+
+    /// Unread-reaction message count for a single chat, aggregated per message.
+    ///
+    /// `thread_root_id`: `None` counts reactions on the user's top-level
+    /// messages (cursor: `group_membership.last_reactions_read_at`);
+    /// `Some(id)` counts reactions on the user's messages in that thread
+    /// (cursor: `thread_user_states.last_reactions_read_at`). The read cursor
+    /// is read here so callers never handle the timestamp.
+    pub fn count_chat_unread_reactions(
+        &self,
+        conn: &mut PgConnection,
+        uid: i32,
+        chat_id: i64,
+        thread_root_id: Option<i64>,
+    ) -> Result<i64, DieselError> {
+        let sql = format!(
+            "SELECT COUNT(DISTINCT mr.message_id)::BIGINT AS reaction_count {UNREAD_REACTIONS_FILTER} {}",
+            match thread_root_id {
+                Some(_) => UNREAD_REACTIONS_THREAD_TAIL,
+                None => UNREAD_REACTIONS_MAIN_TAIL,
+            }
+        );
+        let row: ReactionTotalRow = match thread_root_id {
+            Some(thread_id) => sql_query(&sql)
+                .bind::<diesel::sql_types::Integer, _>(uid)
+                .bind::<diesel::sql_types::BigInt, _>(chat_id)
+                .bind::<diesel::sql_types::BigInt, _>(thread_id)
+                .get_result(conn)?,
+            None => sql_query(&sql)
+                .bind::<diesel::sql_types::Integer, _>(uid)
+                .bind::<diesel::sql_types::BigInt, _>(chat_id)
+                .get_result(conn)?,
+        };
+        Ok(row.reaction_count.min(MAX_UNREAD_COUNT))
+    }
+
+    /// Unread-reaction message ids for a single chat, newest-first, one entry
+    /// per message regardless of how many new reactions it carries.
+    ///
+    /// Same derivation and scope rules as `count_chat_unread_reactions`. The
+    /// limit is interpolated instead of bound so both scope variants share one
+    /// placeholder layout (`limit` is a validated `i64` from `validate_limit`).
+    pub fn list_chat_unread_reactions(
+        &self,
+        conn: &mut PgConnection,
+        uid: i32,
+        chat_id: i64,
+        thread_root_id: Option<i64>,
+        limit: i64,
+    ) -> Result<Vec<i64>, DieselError> {
+        let sql = format!(
+            "SELECT DISTINCT mr.message_id AS message_id {UNREAD_REACTIONS_FILTER} {} \
+             ORDER BY mr.message_id DESC LIMIT {limit}",
+            match thread_root_id {
+                Some(_) => UNREAD_REACTIONS_THREAD_TAIL,
+                None => UNREAD_REACTIONS_MAIN_TAIL,
+            }
+        );
+        let rows: Vec<UnreadReactionIdRow> = match thread_root_id {
+            Some(thread_id) => sql_query(&sql)
+                .bind::<diesel::sql_types::Integer, _>(uid)
+                .bind::<diesel::sql_types::BigInt, _>(chat_id)
+                .bind::<diesel::sql_types::BigInt, _>(thread_id)
+                .load(conn)?,
+            None => sql_query(&sql)
+                .bind::<diesel::sql_types::Integer, _>(uid)
+                .bind::<diesel::sql_types::BigInt, _>(chat_id)
+                .load(conn)?,
+        };
+        Ok(rows.into_iter().map(|r| r.message_id).collect())
     }
 
     pub fn observe_top_level_message(&self, chat_id: i64, message_id: i64, is_counted: bool) {
@@ -825,5 +1092,300 @@ mod tests {
         let totals = totals.unwrap();
         assert_eq!(totals.get(&10), Some(&MAX_UNREAD_COUNT));
         assert_eq!(totals.get(&11), Some(&2));
+    }
+
+    /// Verifies `message_mentions` are counted as unread and auto-clear once the
+    /// chat read pointer advances past the mentioned message. Requires a test
+    /// database (`WETTY_TEST_DATABASE_URL`); skipped otherwise. Runs inside a
+    /// transaction that always rolls back, so it leaves no persistent data.
+    #[test]
+    fn message_mentions_unread_count_and_auto_clear_on_read() {
+        use diesel::Connection;
+        use diesel::PgConnection;
+        use diesel::RunQueryDsl;
+        use std::sync::atomic::{AtomicI64, Ordering};
+
+        let url = match std::env::var("WETTY_TEST_DATABASE_URL") {
+            Ok(u) => u,
+            Err(_) => {
+                eprintln!("skipping (WETTY_TEST_DATABASE_URL unset)");
+                return;
+            }
+        };
+        let mut conn = PgConnection::establish(&url).expect("connect to test database");
+
+        static SEQ: AtomicI64 = AtomicI64::new(9_876_543_000);
+        let chat_id = SEQ.fetch_add(1, Ordering::SeqCst);
+        let msg_id = SEQ.fetch_add(1, Ordering::SeqCst);
+        let user: i32 = 4242;
+        let sender: i32 = 1717;
+        let service = UnreadService::new();
+
+        let result = conn.transaction::<(), diesel::result::Error, _>(|conn| {
+            diesel::sql_query("INSERT INTO groups (id, name) VALUES ($1, 'mention-test')")
+                .bind::<diesel::sql_types::BigInt, _>(chat_id)
+                .execute(conn)?;
+            diesel::sql_query("INSERT INTO group_membership (chat_id, uid) VALUES ($1, $2)")
+                .bind::<diesel::sql_types::BigInt, _>(chat_id)
+                .bind::<diesel::sql_types::Integer, _>(user)
+                .execute(conn)?;
+            diesel::sql_query(
+                "INSERT INTO messages (id, message_type, client_generated_id, sender_uid, chat_id, created_at) \
+                 VALUES ($1, 'text', $2, $3, $4, NOW())",
+            )
+            .bind::<diesel::sql_types::BigInt, _>(msg_id)
+            .bind::<diesel::sql_types::Text, _>(format!("cg-{chat_id}-{msg_id}"))
+            .bind::<diesel::sql_types::Integer, _>(sender)
+            .bind::<diesel::sql_types::BigInt, _>(chat_id)
+            .execute(conn)?;
+            diesel::sql_query(
+                "INSERT INTO message_mentions (message_id, mentioned_uid, chat_id, thread_root_id, created_at) \
+                 VALUES ($1, $2, $3, NULL, NOW())",
+            )
+            .bind::<diesel::sql_types::BigInt, _>(msg_id)
+            .bind::<diesel::sql_types::Integer, _>(user)
+            .bind::<diesel::sql_types::BigInt, _>(chat_id)
+            .execute(conn)?;
+
+            // last_read_message_id is NULL -> treated as 0 -> mention is unread.
+            let counts = service.count_user_chat_unread_mentions(conn, user)?;
+            assert_eq!(counts.get(&chat_id).copied(), Some(1));
+
+            // Reading up to the mentioned message clears the unread mention.
+            diesel::sql_query(
+                "UPDATE group_membership SET last_read_message_id = $1 \
+                 WHERE chat_id = $2 AND uid = $3",
+            )
+            .bind::<diesel::sql_types::BigInt, _>(msg_id)
+            .bind::<diesel::sql_types::BigInt, _>(chat_id)
+            .bind::<diesel::sql_types::Integer, _>(user)
+            .execute(conn)?;
+            let counts_after = service.count_user_chat_unread_mentions(conn, user)?;
+            assert!(counts_after.get(&chat_id).copied().is_none());
+
+            Err(diesel::result::Error::RollbackTransaction)
+        });
+
+        assert!(
+            matches!(result, Err(diesel::result::Error::RollbackTransaction)),
+            "transaction should roll back"
+        );
+    }
+
+    #[test]
+    fn list_chat_unread_mentions_returns_newest_first_and_respects_scope_and_cursor() {
+        use diesel::Connection;
+        use diesel::PgConnection;
+        use diesel::RunQueryDsl;
+        use std::sync::atomic::{AtomicI64, Ordering};
+
+        let url = match std::env::var("WETTY_TEST_DATABASE_URL") {
+            Ok(u) => u,
+            Err(_) => {
+                eprintln!("skipping (WETTY_TEST_DATABASE_URL unset)");
+                return;
+            }
+        };
+        let mut conn = PgConnection::establish(&url).expect("connect to test database");
+
+        static SEQ: AtomicI64 = AtomicI64::new(9_876_554_000);
+        let chat_id = SEQ.fetch_add(1, Ordering::SeqCst);
+        let thread_root_id = SEQ.fetch_add(1, Ordering::SeqCst);
+        // main-scope mentions, older -> newer; main_old/main_mid will be read (<= cursor).
+        let main_old = SEQ.fetch_add(1, Ordering::SeqCst);
+        let main_mid = SEQ.fetch_add(1, Ordering::SeqCst);
+        let main_new = SEQ.fetch_add(1, Ordering::SeqCst);
+        // thread-scope mention.
+        let thread_msg = SEQ.fetch_add(1, Ordering::SeqCst);
+        let user: i32 = 4243;
+        let sender: i32 = 1718;
+        let service = UnreadService::new();
+
+        let result = conn.transaction::<(), diesel::result::Error, _>(|conn| {
+            diesel::sql_query("INSERT INTO groups (id, name) VALUES ($1, 'mention-list-test')")
+                .bind::<diesel::sql_types::BigInt, _>(chat_id)
+                .execute(conn)?;
+            diesel::sql_query("INSERT INTO group_membership (chat_id, uid) VALUES ($1, $2)")
+                .bind::<diesel::sql_types::BigInt, _>(chat_id)
+                .bind::<diesel::sql_types::Integer, _>(user)
+                .execute(conn)?;
+
+            for msg_id in [main_old, main_mid, main_new, thread_msg] {
+                diesel::sql_query(
+                    "INSERT INTO messages (id, message_type, client_generated_id, sender_uid, chat_id, created_at) \
+                     VALUES ($1, 'text', $2, $3, $4, NOW())",
+                )
+                .bind::<diesel::sql_types::BigInt, _>(msg_id)
+                .bind::<diesel::sql_types::Text, _>(format!("cg-{chat_id}-{msg_id}"))
+                .bind::<diesel::sql_types::Integer, _>(sender)
+                .bind::<diesel::sql_types::BigInt, _>(chat_id)
+                .execute(conn)?;
+            }
+
+            // main_old / main_mid / main_new are main-scope (thread_root_id NULL).
+            for msg_id in [main_old, main_mid, main_new] {
+                diesel::sql_query(
+                    "INSERT INTO message_mentions (message_id, mentioned_uid, chat_id, thread_root_id, created_at) \
+                     VALUES ($1, $2, $3, NULL, NOW())",
+                )
+                .bind::<diesel::sql_types::BigInt, _>(msg_id)
+                .bind::<diesel::sql_types::Integer, _>(user)
+                .bind::<diesel::sql_types::BigInt, _>(chat_id)
+                .execute(conn)?;
+            }
+            // thread_msg is thread-scoped (thread_root_id set).
+            diesel::sql_query(
+                "INSERT INTO message_mentions (message_id, mentioned_uid, chat_id, thread_root_id, created_at) \
+                 VALUES ($1, $2, $3, $4, NOW())",
+            )
+            .bind::<diesel::sql_types::BigInt, _>(thread_msg)
+            .bind::<diesel::sql_types::Integer, _>(user)
+            .bind::<diesel::sql_types::BigInt, _>(chat_id)
+            .bind::<diesel::sql_types::BigInt, _>(thread_root_id)
+            .execute(conn)?;
+
+            // Cursor NULL -> all main-scope mentions unread, newest-first.
+            let main_ids = service.list_chat_unread_mentions(
+                conn, user, chat_id, None, None, 100,
+            )?;
+            assert_eq!(main_ids, vec![main_new, main_mid, main_old]);
+
+            // Thread scope excludes main-scope mentions.
+            let thread_ids = service.list_chat_unread_mentions(
+                conn, user, chat_id, None, Some(thread_root_id), 100,
+            )?;
+            assert_eq!(thread_ids, vec![thread_msg]);
+
+            // Advancing the cursor to main_mid marks main_old + main_mid as read.
+            let after_mid = service.list_chat_unread_mentions(
+                conn, user, chat_id, Some(main_mid), None, 100,
+            )?;
+            assert_eq!(after_mid, vec![main_new]);
+
+            // LIMIT caps the result.
+            let limited = service.list_chat_unread_mentions(
+                conn, user, chat_id, None, None, 2,
+            )?;
+            assert_eq!(limited, vec![main_new, main_mid]);
+
+            Err(diesel::result::Error::RollbackTransaction)
+        });
+
+        assert!(
+            matches!(result, Err(diesel::result::Error::RollbackTransaction)),
+            "transaction should roll back"
+        );
+    }
+
+    /// Reply rows (kind='reply') ride the same unread-mention pipeline as
+    /// @mentions: they count towards unread mentions, appear in the jump list
+    /// for both main and thread scope, and clear when the read cursor advances.
+    /// Requires a test database (`WETTY_TEST_DATABASE_URL`); skipped otherwise.
+    #[test]
+    fn reply_kind_mention_rows_flow_through_unread_pipeline() {
+        use diesel::Connection;
+        use diesel::PgConnection;
+        use diesel::RunQueryDsl;
+        use std::sync::atomic::{AtomicI64, Ordering};
+
+        let url = match std::env::var("WETTY_TEST_DATABASE_URL") {
+            Ok(u) => u,
+            Err(_) => {
+                eprintln!("skipping (WETTY_TEST_DATABASE_URL unset)");
+                return;
+            }
+        };
+        let mut conn = PgConnection::establish(&url).expect("connect to test database");
+
+        static SEQ: AtomicI64 = AtomicI64::new(9_876_565_000);
+        let chat_id = SEQ.fetch_add(1, Ordering::SeqCst);
+        let thread_root_id = SEQ.fetch_add(1, Ordering::SeqCst);
+        let mention_msg = SEQ.fetch_add(1, Ordering::SeqCst);
+        let reply_msg = SEQ.fetch_add(1, Ordering::SeqCst);
+        let thread_reply_msg = SEQ.fetch_add(1, Ordering::SeqCst);
+        let user: i32 = 4244;
+        let sender: i32 = 1719;
+        let service = UnreadService::new();
+
+        let result = conn.transaction::<(), diesel::result::Error, _>(|conn| {
+            diesel::sql_query("INSERT INTO groups (id, name) VALUES ($1, 'reply-mention-test')")
+                .bind::<diesel::sql_types::BigInt, _>(chat_id)
+                .execute(conn)?;
+            diesel::sql_query("INSERT INTO group_membership (chat_id, uid) VALUES ($1, $2)")
+                .bind::<diesel::sql_types::BigInt, _>(chat_id)
+                .bind::<diesel::sql_types::Integer, _>(user)
+                .execute(conn)?;
+
+            for msg_id in [mention_msg, reply_msg, thread_reply_msg] {
+                diesel::sql_query(
+                    "INSERT INTO messages (id, message_type, client_generated_id, sender_uid, chat_id, created_at) \
+                     VALUES ($1, 'text', $2, $3, $4, NOW())",
+                )
+                .bind::<diesel::sql_types::BigInt, _>(msg_id)
+                .bind::<diesel::sql_types::Text, _>(format!("cg-{chat_id}-{msg_id}"))
+                .bind::<diesel::sql_types::Integer, _>(sender)
+                .bind::<diesel::sql_types::BigInt, _>(chat_id)
+                .execute(conn)?;
+            }
+
+            // One explicit @mention row and two reply rows (main + thread scope).
+            diesel::sql_query(
+                "INSERT INTO message_mentions (message_id, mentioned_uid, chat_id, thread_root_id, created_at, kind) \
+                 VALUES ($1, $2, $3, NULL, NOW(), 'mention')",
+            )
+            .bind::<diesel::sql_types::BigInt, _>(mention_msg)
+            .bind::<diesel::sql_types::Integer, _>(user)
+            .bind::<diesel::sql_types::BigInt, _>(chat_id)
+            .execute(conn)?;
+            diesel::sql_query(
+                "INSERT INTO message_mentions (message_id, mentioned_uid, chat_id, thread_root_id, created_at, kind) \
+                 VALUES ($1, $2, $3, NULL, NOW(), 'reply')",
+            )
+            .bind::<diesel::sql_types::BigInt, _>(reply_msg)
+            .bind::<diesel::sql_types::Integer, _>(user)
+            .bind::<diesel::sql_types::BigInt, _>(chat_id)
+            .execute(conn)?;
+            diesel::sql_query(
+                "INSERT INTO message_mentions (message_id, mentioned_uid, chat_id, thread_root_id, created_at, kind) \
+                 VALUES ($1, $2, $3, $4, NOW(), 'reply')",
+            )
+            .bind::<diesel::sql_types::BigInt, _>(thread_reply_msg)
+            .bind::<diesel::sql_types::Integer, _>(user)
+            .bind::<diesel::sql_types::BigInt, _>(chat_id)
+            .bind::<diesel::sql_types::BigInt, _>(thread_root_id)
+            .execute(conn)?;
+
+            // Reply rows count as unread mentions alongside the @mention.
+            let counts = service.count_user_chat_unread_mentions(conn, user)?;
+            assert_eq!(counts.get(&chat_id).copied(), Some(2));
+
+            // The jump list includes reply rows, newest-first, scope-respected.
+            let main_ids =
+                service.list_chat_unread_mentions(conn, user, chat_id, None, None, 100)?;
+            assert_eq!(main_ids, vec![reply_msg, mention_msg]);
+            let thread_ids = service.list_chat_unread_mentions(
+                conn, user, chat_id, None, Some(thread_root_id), 100,
+            )?;
+            assert_eq!(thread_ids, vec![thread_reply_msg]);
+
+            // Reading up to the reply message clears both rows.
+            diesel::sql_query(
+                "UPDATE group_membership SET last_read_message_id = $1 \
+                 WHERE chat_id = $2 AND uid = $3",
+            )
+            .bind::<diesel::sql_types::BigInt, _>(reply_msg)
+            .bind::<diesel::sql_types::BigInt, _>(chat_id)
+            .bind::<diesel::sql_types::Integer, _>(user)
+            .execute(conn)?;
+            let counts_after = service.count_user_chat_unread_mentions(conn, user)?;
+            assert!(counts_after.get(&chat_id).copied().is_none());
+
+            Err(diesel::result::Error::RollbackTransaction)
+        });
+
+        assert!(
+            matches!(result, Err(diesel::result::Error::RollbackTransaction)),
+            "transaction should roll back"
+        );
     }
 }


### PR DESCRIPTION
- Added message_mentions table: @mentions persisted on message send (member-filtered, sender excluded) and cleaned up on message delete; mentions stay in sync when a message is edited.
- Replies ride the same mention pipeline: "someone replied to me" lights up the same badges and jump lists, and a message that both mentions and replies to the same person notifies once.
- Added an independent reaction pipeline: unread reaction counts are derived from reactions on my messages against a per-user read cursor that advances on mark-read.
- Unread-mention and unread-reaction counts exposed on ChatListItem, ThreadListItem, and the read/unread responses; also new GET /chats/{id}/mentions and GET /chats/{id}/reactions endpoints returning newest-first unread id lists for jump navigation.
- Typed push payload: mention and reply recipients get directed push copy and a dedicated APNs loc-key; reply targets get a one-off push even without a thread subscription.
- Directed ServerWsMessage::Notification WS event (mention / reply / reaction) delivered to each affected member.