### PR TITLE
Ml/pwa markdown support

### DIFF
--- a/wetty-chat-mobile/locales/en/messages.po
+++ b/wetty-chat-mobile/locales/en/messages.po
@@ -161,6 +161,9 @@ msgstr "Block User"
 msgid "Blocked"
 msgstr "Blocked"
 
+msgid "Bold (Ctrl+B)"
+msgstr "Bold (Ctrl+B)"
+
 msgid "Cancel"
 msgstr "Cancel"
 
@@ -227,6 +230,9 @@ msgstr "Close viewer"
 
 msgid "Code"
 msgstr "Code"
+
+msgid "Code block"
+msgstr "Code block"
 
 msgid "Compressing"
 msgstr "Compressing"
@@ -716,6 +722,9 @@ msgstr "Invite Type"
 msgid "Invite unavailable"
 msgstr "Invite unavailable"
 
+msgid "Italic (Ctrl+I)"
+msgstr "Italic (Ctrl+I)"
+
 msgid "Join chat"
 msgstr "Join chat"
 
@@ -1089,6 +1098,9 @@ msgstr "Q: {0} · A: {1}"
 msgid "Question"
 msgstr "Question"
 
+msgid "Quote (Ctrl+Q)"
+msgstr "Quote (Ctrl+Q)"
+
 msgid "Reactions"
 msgstr "Reactions"
 
@@ -1343,6 +1355,9 @@ msgstr "stickers"
 msgid "Stickers must be an image or a WebM video."
 msgstr "Stickers must be an image or a WebM video."
 
+msgid "Strikethrough (Ctrl+D)"
+msgstr "Strikethrough (Ctrl+D)"
+
 msgid "Subscribe"
 msgstr "Subscribe"
 
@@ -1450,6 +1465,9 @@ msgstr "Unblock this user?"
 
 msgid "Unblock User"
 msgstr "Unblock User"
+
+msgid "Underline (Ctrl+U)"
+msgstr "Underline (Ctrl+U)"
 
 msgid "Unfavorite"
 msgstr "Unfavorite"

--- a/wetty-chat-mobile/locales/zh-CN/messages.po
+++ b/wetty-chat-mobile/locales/zh-CN/messages.po
@@ -161,6 +161,9 @@ msgstr "拉黑用户"
 msgid "Blocked"
 msgstr "已阻止"
 
+msgid "Bold (Ctrl+B)"
+msgstr "粗体 (Ctrl+B)"
+
 msgid "Cancel"
 msgstr "取消"
 
@@ -227,6 +230,9 @@ msgstr "关闭查看器"
 
 msgid "Code"
 msgstr "邀请码"
+
+msgid "Code block"
+msgstr "代码块"
 
 msgid "Compressing"
 msgstr "压缩中"
@@ -716,6 +722,9 @@ msgstr "邀请类型"
 msgid "Invite unavailable"
 msgstr "邀请不可用"
 
+msgid "Italic (Ctrl+I)"
+msgstr "斜体 (Ctrl+I)"
+
 msgid "Join chat"
 msgstr "加入聊天"
 
@@ -1089,6 +1098,9 @@ msgstr "问：{0} · 答：{1}"
 msgid "Question"
 msgstr "问题"
 
+msgid "Quote (Ctrl+Q)"
+msgstr "引用 (Ctrl+Q)"
+
 msgid "Reactions"
 msgstr "回应"
 
@@ -1343,6 +1355,9 @@ msgstr "个贴纸"
 msgid "Stickers must be an image or a WebM video."
 msgstr "贴纸必须是图片或 WebM 视频。"
 
+msgid "Strikethrough (Ctrl+D)"
+msgstr "删除线 (Ctrl+D)"
+
 msgid "Subscribe"
 msgstr "订阅"
 
@@ -1450,6 +1465,9 @@ msgstr "取消拉黑该用户？"
 
 msgid "Unblock User"
 msgstr "取消拉黑用户"
+
+msgid "Underline (Ctrl+U)"
+msgstr "下划线 (Ctrl+U)"
 
 msgid "Unfavorite"
 msgstr "取消收藏"

--- a/wetty-chat-mobile/locales/zh-TW/messages.po
+++ b/wetty-chat-mobile/locales/zh-TW/messages.po
@@ -161,6 +161,9 @@ msgstr "封鎖使用者"
 msgid "Blocked"
 msgstr "已封鎖"
 
+msgid "Bold (Ctrl+B)"
+msgstr "粗體 (Ctrl+B)"
+
 msgid "Cancel"
 msgstr "取消"
 
@@ -227,6 +230,9 @@ msgstr "關閉檢視器"
 
 msgid "Code"
 msgstr "邀請碼"
+
+msgid "Code block"
+msgstr "程式碼區塊"
 
 msgid "Compressing"
 msgstr "壓縮中"
@@ -716,6 +722,9 @@ msgstr "邀請類型"
 msgid "Invite unavailable"
 msgstr "邀請無法使用"
 
+msgid "Italic (Ctrl+I)"
+msgstr "斜體 (Ctrl+I)"
+
 msgid "Join chat"
 msgstr "加入聊天"
 
@@ -1089,6 +1098,9 @@ msgstr "問：{0} · 答：{1}"
 msgid "Question"
 msgstr "問題"
 
+msgid "Quote (Ctrl+Q)"
+msgstr "引用 (Ctrl+Q)"
+
 msgid "Reactions"
 msgstr "回應"
 
@@ -1343,6 +1355,9 @@ msgstr "個貼紙"
 msgid "Stickers must be an image or a WebM video."
 msgstr "貼圖必須是圖片或 WebM 影片。"
 
+msgid "Strikethrough (Ctrl+D)"
+msgstr "刪除線 (Ctrl+D)"
+
 msgid "Subscribe"
 msgstr "訂閱"
 
@@ -1450,6 +1465,9 @@ msgstr "解除封鎖該使用者？"
 
 msgid "Unblock User"
 msgstr "解除封鎖使用者"
+
+msgid "Underline (Ctrl+U)"
+msgstr "底線 (Ctrl+U)"
 
 msgid "Unfavorite"
 msgstr "取消收藏"

--- a/wetty-chat-mobile/package-lock.json
+++ b/wetty-chat-mobile/package-lock.json
@@ -23,6 +23,7 @@
         "idb": "^8.0.3",
         "ionicons": "^8.0.13",
         "js-cookie": "^3.0.5",
+        "markdown-it": "^15.0.1",
         "mediabunny": "^1.52.3",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -7808,6 +7809,25 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "devOptional": true
     },
+    "node_modules/linkify-it": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-6.1.0.tgz",
+      "integrity": "sha512-wJ/TwpSDTLepCrQoYWYIExIKg5Zchex2Nn5yk2mFnB+6PtdkHtyLx742md9csRjjOnGkKIS/RrbY7l8D6gT9Vw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^3.0.0"
+      }
+    },
     "node_modules/loader-utils": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.3.1.tgz",
@@ -7939,6 +7959,61 @@
         "node": ">=10"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-15.0.1.tgz",
+      "integrity": "sha512-9/7gE95FNPkfUWrjJIoHZza2iLmuJlPD0UNMxPi7bxUrbCR525YZY0r+zyfes0dZI5ZZ/uNIXUJca0pJvtw41g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^3.0.0",
+        "entities": "^8.0.0",
+        "linkify-it": "^6.0.0",
+        "mdurl": "^2.1.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^3.0.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/argparse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-3.0.1.tgz",
+      "integrity": "sha512-nM4mHF/KM1v59ZNKX7zfusQz5wUAxR511YG8Vo6TyiV4aqhu++rbJW4v04xsWhpSsHFj66flT8P7znVpyO20xQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "PSF-2.0"
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -7946,6 +8021,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.1.0.tgz",
+      "integrity": "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==",
+      "license": "MIT"
     },
     "node_modules/mediabunny": {
       "version": "1.52.3",
@@ -8612,6 +8693,15 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -10052,6 +10142,12 @@
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-3.0.0.tgz",
+      "integrity": "sha512-U3PppEkleoTnIfi8BozMx3yju3qc/L6SwqWo2Sw+54PX+PX0q9I+r1Um5HCmqD7n9VDX5/v3vQH/AjA6deDdtw==",
+      "license": "MIT"
     },
     "node_modules/uint8array-extras": {
       "version": "1.5.0",

--- a/wetty-chat-mobile/package.json
+++ b/wetty-chat-mobile/package.json
@@ -41,6 +41,7 @@
     "idb": "^8.0.3",
     "ionicons": "^8.0.13",
     "js-cookie": "^3.0.5",
+    "markdown-it": "^15.0.1",
     "mediabunny": "^1.52.3",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/wetty-chat-mobile/src/components/chat/compose/ComposeContextBanner.tsx
+++ b/wetty-chat-mobile/src/components/chat/compose/ComposeContextBanner.tsx
@@ -5,6 +5,7 @@ import { useSelector } from 'react-redux';
 import { selectEffectiveLocale } from '@/store/settingsSlice';
 import { useChatContext } from '@/components/chat/messages/ChatContext';
 import { formatMessagePreview, getNotificationPreviewLabels } from '@/utils/messagePreview';
+import { MarkdownSummaryText } from '@/components/chat/previews/MarkdownSummaryText';
 import type { EditingMessage, ReplyTo } from './types';
 import styles from './MessageComposeBar.module.scss';
 
@@ -47,7 +48,9 @@ export function ComposeContextBanner({ editing, replyTo, onCancelEdit, onCancelR
       <div className={`${styles.replyText} ${styles.replyPreviewTappable}`} onClick={handleJumpToReply}>
         <span className={styles.replyUsername}>{t`Replying to ${replyTo.username}`}</span>
         <span className={styles.replySnippet}>
-          {formatMessagePreview(replyTo, getNotificationPreviewLabels(locale))}
+          <MarkdownSummaryText
+            text={formatMessagePreview(replyTo, getNotificationPreviewLabels(locale))}
+          />
         </span>
       </div>
       <button type="button" className={styles.replyClose} aria-label={t`Cancel reply`} onClick={onCancelReply}>

--- a/wetty-chat-mobile/src/components/chat/compose/ComposeContextBanner.tsx
+++ b/wetty-chat-mobile/src/components/chat/compose/ComposeContextBanner.tsx
@@ -48,9 +48,7 @@ export function ComposeContextBanner({ editing, replyTo, onCancelEdit, onCancelR
       <div className={`${styles.replyText} ${styles.replyPreviewTappable}`} onClick={handleJumpToReply}>
         <span className={styles.replyUsername}>{t`Replying to ${replyTo.username}`}</span>
         <span className={styles.replySnippet}>
-          <MarkdownSummaryText
-            text={formatMessagePreview(replyTo, getNotificationPreviewLabels(locale))}
-          />
+          <MarkdownSummaryText text={formatMessagePreview(replyTo, getNotificationPreviewLabels(locale))} />
         </span>
       </div>
       <button type="button" className={styles.replyClose} aria-label={t`Cancel reply`} onClick={onCancelReply}>

--- a/wetty-chat-mobile/src/components/chat/compose/ComposeInput.dom.test.tsx
+++ b/wetty-chat-mobile/src/components/chat/compose/ComposeInput.dom.test.tsx
@@ -17,6 +17,7 @@ vi.mock('ionicons/icons', () => ({
 }));
 
 vi.mock('./MessageComposeBar.module.scss', () => ({ default: {} }));
+vi.mock('./FormatToolbar.module.scss', () => ({ default: {} }));
 
 const replyTarget: ReplyTo = {
   messageId: 'msg-1',

--- a/wetty-chat-mobile/src/components/chat/compose/ComposeInput.formatting.dom.test.tsx
+++ b/wetty-chat-mobile/src/components/chat/compose/ComposeInput.formatting.dom.test.tsx
@@ -1,0 +1,342 @@
+import { useRef, useState, type ReactElement } from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ComposeInput } from './ComposeInput';
+
+vi.mock('@lingui/core/macro', () => ({
+  t: (strings: TemplateStringsArray | string) => (typeof strings === 'string' ? strings : strings.join('')),
+}));
+vi.mock('@ionic/react', () => ({
+  IonIcon: () => null,
+}));
+vi.mock('ionicons/icons', () => ({
+  happyOutline: 'happy-outline',
+  linkOutline: 'link-outline',
+}));
+vi.mock('./MessageComposeBar.module.scss', () => ({ default: {} }));
+vi.mock('./FormatToolbar.module.scss', () => ({ default: {} }));
+
+const featureMocks = vi.hoisted(() => ({
+  isFeatureEnabled: vi.fn<(name: string) => boolean>(),
+}));
+vi.mock('@/features', () => ({
+  isFeatureEnabled: featureMocks.isFeatureEnabled,
+}));
+
+const BODY_PORTAL_SELECTOR = '[data-format-toolbar]';
+
+let container: HTMLDivElement;
+let root: Root;
+
+function Harness({
+  initialText = '',
+  mentionOpen = false,
+}: {
+  initialText?: string;
+  mentionOpen?: boolean;
+}): ReactElement {
+  const [text, setText] = useState(initialText);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  return (
+    <div>
+      <ComposeInput
+        textareaRef={textareaRef}
+        text={text}
+        onTextChange={setText}
+        onSubmit={() => {}}
+        canRequestRecentEdit={false}
+        onRequestEditLastMessage={() => false}
+        isUnchangedEdit={false}
+        onCancelEdit={() => {}}
+        onCancelReply={() => {}}
+        onStickerPress={() => {}}
+        isStickerActive={false}
+        onMentionKeyDown={() => false}
+        isMentionMenuOpen={mentionOpen}
+      />
+    </div>
+  );
+}
+
+function renderHarness(props: { initialText?: string; mentionOpen?: boolean } = {}) {
+  act(() => {
+    root.render(<Harness {...props} />);
+  });
+}
+
+function textarea(): HTMLTextAreaElement {
+  const el = container.querySelector('textarea');
+  if (!el) throw new Error('textarea not rendered');
+  return el;
+}
+
+async function flushTimers() {
+  await act(async () => {
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+  });
+}
+
+async function focusTextarea() {
+  await act(async () => {
+    textarea().dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+  });
+}
+
+async function selectRange(start: number, end: number) {
+  await act(async () => {
+    const ta = textarea();
+    ta.setSelectionRange(start, end);
+    ta.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+  });
+}
+
+async function openSelection(start: number, end: number) {
+  await focusTextarea();
+  await selectRange(start, end);
+}
+
+function typeInto(input: HTMLInputElement, value: string) {
+  const valueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+  act(() => {
+    valueSetter?.call(input, value);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+}
+
+function fireKeydown(key: string, init: KeyboardEventInit = {}) {
+  act(() => {
+    textarea().dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true, ...init }));
+  });
+}
+
+function toolbar(): HTMLElement | null {
+  return document.body.querySelector(BODY_PORTAL_SELECTOR);
+}
+
+function clickToolbarButton(selector: string) {
+  const target = document.body.querySelector(selector);
+  if (!target) throw new Error(`missing ${selector}`);
+  act(() => {
+    target.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
+    target.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+  });
+}
+
+beforeEach(() => {
+  featureMocks.isFeatureEnabled.mockReset();
+  featureMocks.isFeatureEnabled.mockReturnValue(true);
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+  document.body.querySelectorAll(BODY_PORTAL_SELECTOR).forEach((el) => el.remove());
+});
+
+describe('ComposeInput formatting toolbar', () => {
+  it('shows the floating toolbar when text is selected and hides it on collapse', async () => {
+    renderHarness({ initialText: 'hello world' });
+    await openSelection(0, 5);
+
+    expect(toolbar()).not.toBeNull();
+
+    act(() => {
+      const ta = textarea();
+      ta.setSelectionRange(5, 5);
+      ta.dispatchEvent(new KeyboardEvent('keyup', { key: 'ArrowRight', bubbles: true }));
+    });
+    await flushTimers();
+
+    expect(toolbar()).toBeNull();
+  });
+
+  it('keeps the toolbar hidden while the mention menu is open', async () => {
+    renderHarness({ initialText: 'hello @', mentionOpen: true });
+    await openSelection(0, 5);
+
+    expect(toolbar()).toBeNull();
+  });
+
+  it('hides the toolbar when the textarea loses focus', async () => {
+    renderHarness({ initialText: 'hello world' });
+    await openSelection(0, 5);
+    expect(toolbar()).not.toBeNull();
+
+    await act(async () => {
+      textarea().dispatchEvent(new FocusEvent('focusout', { bubbles: true }));
+    });
+    expect(toolbar()).toBeNull();
+  });
+
+  it('does not show the toolbar when the feature gate is off', async () => {
+    featureMocks.isFeatureEnabled.mockReturnValue(false);
+    renderHarness({ initialText: 'hello world' });
+    await openSelection(0, 5);
+
+    expect(toolbar()).toBeNull();
+  });
+});
+
+describe('ComposeInput formatting buttons', () => {
+  it('wraps the selection in ** via the toolbar bold button', async () => {
+    renderHarness({ initialText: 'hello world' });
+    await openSelection(0, 5);
+
+    clickToolbarButton('[data-format-bold]');
+    await flushTimers();
+
+    expect(textarea().value).toBe('**hello** world');
+    // Cursor sits right after the closing marker, toolbar hidden.
+    expect(textarea().selectionStart).toBe(9);
+    expect(textarea().selectionEnd).toBe(9);
+    expect(toolbar()).toBeNull();
+  });
+
+  it('wraps the selection in * / ~~ via italic and strike buttons', async () => {
+    renderHarness({ initialText: 'hello world' });
+    await openSelection(0, 5);
+
+    clickToolbarButton('[data-format-italic]');
+    await flushTimers();
+    expect(textarea().value).toBe('*hello* world');
+
+    // In "*hello* world", "world" spans 8..13.
+    await openSelection(8, 13);
+    clickToolbarButton('[data-format-strike]');
+    await flushTimers();
+    expect(textarea().value).toBe('*hello* ~~world~~');
+  });
+
+  it('wraps the selection in __ via the toolbar underline button', async () => {
+    renderHarness({ initialText: 'hello world' });
+    await openSelection(0, 5);
+
+    clickToolbarButton('[data-format-underline]');
+    await flushTimers();
+
+    expect(textarea().value).toBe('__hello__ world');
+    expect(textarea().selectionStart).toBe(9);
+    expect(textarea().selectionEnd).toBe(9);
+    expect(toolbar()).toBeNull();
+  });
+
+  it('fences the selection via the toolbar code button', async () => {
+    renderHarness({ initialText: 'hello world' });
+    await openSelection(0, 5);
+
+    clickToolbarButton('[data-format-code]');
+    await flushTimers();
+
+    expect(textarea().value).toBe('```\nhello\n``` world');
+    expect(toolbar()).toBeNull();
+  });
+
+  it('prefixes every selected line with > via the toolbar quote button', async () => {
+    renderHarness({ initialText: 'first\nsecond' });
+    await openSelection(0, 12);
+
+    clickToolbarButton('[data-format-quote]');
+    await flushTimers();
+
+    expect(textarea().value).toBe('> first\n> second');
+    expect(toolbar()).toBeNull();
+  });
+
+  it('applies a typed link URL to the selection', async () => {
+    renderHarness({ initialText: 'see hello now' });
+    await openSelection(4, 9);
+
+    clickToolbarButton('[data-format-link]');
+    await flushTimers();
+
+    const input = document.body.querySelector('[data-format-url-input]') as HTMLInputElement | null;
+    expect(input).not.toBeNull();
+    typeInto(input!, 'example.com/docs');
+    clickToolbarButton('[data-format-url-apply]');
+    await flushTimers();
+
+    expect(textarea().value).toBe('see [hello](https://example.com/docs) now');
+  });
+});
+
+describe('ComposeInput keyboard shortcuts', () => {
+  it('Ctrl+B wraps the selection like the toolbar button', async () => {
+    renderHarness({ initialText: 'hello world' });
+    await openSelection(0, 5);
+
+    fireKeydown('b', { ctrlKey: true });
+    await flushTimers();
+
+    expect(textarea().value).toBe('**hello** world');
+    expect(toolbar()).toBeNull();
+  });
+
+  it('Ctrl+I and Cmd+D wrap the selection', async () => {
+    renderHarness({ initialText: 'one two' });
+    await openSelection(0, 3);
+    fireKeydown('i', { ctrlKey: true });
+    await flushTimers();
+    expect(textarea().value).toBe('*one* two');
+
+    // In "*one* two", "two" spans 6..9.
+    await openSelection(6, 9);
+    fireKeydown('d', { metaKey: true });
+    await flushTimers();
+    expect(textarea().value).toBe('*one* ~~two~~');
+  });
+
+  it('Ctrl+U and Ctrl+Q wrap underline and quote the selection', async () => {
+    renderHarness({ initialText: 'hello world' });
+    await openSelection(0, 5);
+
+    fireKeydown('u', { ctrlKey: true });
+    await flushTimers();
+    expect(textarea().value).toBe('__hello__ world');
+
+    // In "__hello__ world", "world" spans 10..15.
+    await openSelection(10, 15);
+    fireKeydown('q', { ctrlKey: true });
+    await flushTimers();
+    expect(textarea().value).toBe('__hello__ > world');
+  });
+
+  it('collapsed selection is a no-op: no stray markers are inserted', async () => {
+    renderHarness({ initialText: 'plain' });
+    await focusTextarea();
+
+    fireKeydown('b', { ctrlKey: true });
+    await flushTimers();
+
+    expect(textarea().value).toBe('plain');
+    expect(toolbar()).toBeNull();
+  });
+
+  it('does not fire formatting shortcuts during IME composition', async () => {
+    renderHarness({ initialText: 'plain' });
+    await focusTextarea();
+    // Set a selection but pretend the OS is still composing.
+    await selectRange(0, 5);
+
+    act(() => {
+      textarea().dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'b',
+          ctrlKey: true,
+          bubbles: true,
+          cancelable: true,
+          isComposing: true,
+        }),
+      );
+    });
+    await flushTimers();
+
+    expect(textarea().value).toBe('plain');
+  });
+});

--- a/wetty-chat-mobile/src/components/chat/compose/ComposeInput.tsx
+++ b/wetty-chat-mobile/src/components/chat/compose/ComposeInput.tsx
@@ -1,7 +1,18 @@
-import { useEffect } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { IonIcon } from '@ionic/react';
 import { t } from '@lingui/core/macro';
 import { happyOutline } from 'ionicons/icons';
+import { isFeatureEnabled } from '@/features';
+import {
+  applyLink,
+  shortcutFormatKind,
+  wrapBlockFormat,
+  wrapInlineFormat,
+  type BlockFormatKind,
+  type TextFormatKind,
+} from '@/utils/textFormat';
+import { FormatToolbar, type FormatToolbarAnchor } from './FormatToolbar';
 import type { EditingMessage, ReplyTo } from './types';
 import styles from './MessageComposeBar.module.scss';
 
@@ -37,6 +48,19 @@ function checkIsVirtualKeyboard(): boolean {
   return false;
 }
 
+/**
+ * Commit a new value into a React-controlled <textarea> exactly the way the
+ * mention autocomplete inserts text: use the native value setter and then fire
+ * an `input` event so React's onChange produces the parent's setState. The
+ * collapsed/new selection is restored on a macrotask so it always runs after
+ * React has re-rendered the committed value.
+ */
+function commitControlledValue(textarea: HTMLTextAreaElement, next: string) {
+  const valueSetter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set;
+  valueSetter?.call(textarea, next);
+  textarea.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
 interface ComposeInputProps {
   textareaRef: React.RefObject<HTMLTextAreaElement | null>;
   text: string;
@@ -53,6 +77,8 @@ interface ComposeInputProps {
   onStickerPress?: () => void;
   isStickerActive?: boolean;
   onMentionKeyDown?: (event: KeyboardEvent) => boolean;
+  /** Mention autocomplete popup open state — used to hide the format pill. */
+  isMentionMenuOpen?: boolean;
 }
 
 export function ComposeInput({
@@ -71,7 +97,67 @@ export function ComposeInput({
   onStickerPress,
   isStickerActive,
   onMentionKeyDown,
+  isMentionMenuOpen = false,
 }: ComposeInputProps) {
+  const [focused, setFocusedState] = useState(false);
+  const [hasSelection, setHasSelection] = useState(false);
+  const [isComposing, setComposing] = useState(false);
+  const [linkMode, setLinkMode] = useState(false);
+  const applyActionRef = useRef<((kind: TextFormatKind, url?: string) => void) | null>(null);
+
+  const measureSelection = () => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    const start = textarea.selectionStart ?? 0;
+    const end = textarea.selectionEnd ?? 0;
+    const selected = end > start;
+    setHasSelection((prev) => (prev === selected ? prev : selected));
+  };
+
+  const applyAction = (kind: TextFormatKind, url?: string) => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+
+    const selection = { start: textarea.selectionStart ?? 0, end: textarea.selectionEnd ?? 0 };
+    const result =
+      kind === 'link'
+        ? url
+          ? applyLink(text, selection, url)
+          : null
+        : kind === 'code' || kind === 'quote'
+          ? wrapBlockFormat(text, selection, kind as BlockFormatKind)
+          : wrapInlineFormat(text, selection, kind);
+    if (!result) return;
+
+    if (kind === 'link') {
+      setLinkMode(false);
+    }
+    commitControlledValue(textarea, result.text);
+    window.setTimeout(() => {
+      textarea.setSelectionRange(result.selectionStart, result.selectionEnd);
+      textarea.focus();
+      measureSelection();
+    }, 0);
+  };
+  // Keep the latest formatter reachable from the keydown listener so shortcuts
+  // never act on a stale closure.
+  useEffect(() => {
+    applyActionRef.current = applyAction;
+  });
+
+  const requestLinkMode = (open: boolean) => {
+    setLinkMode(open);
+    if (!open) {
+      const textarea = textareaRef.current;
+      if (textarea) {
+        textarea.focus();
+        measureSelection();
+      }
+    }
+  };
+
+  const formatEnabled = isFeatureEnabled('messageMarkdown');
+
   useEffect(() => {
     const textarea = textareaRef.current;
     if (!textarea) return;
@@ -86,6 +172,17 @@ export function ComposeInput({
 
       const isImeConfirm = event.isComposing || event.keyCode === 229 || event.which === 229;
       const isVirtualKbd = checkIsVirtualKeyboard();
+
+      // Ctrl/Cmd+B / I / D formatting shortcuts (never during IME composition).
+      if (formatEnabled && !isImeConfirm && !event.altKey && (event.ctrlKey || event.metaKey)) {
+        const kind = shortcutFormatKind(event);
+        if (kind) {
+          event.preventDefault();
+          applyActionRef.current?.(kind);
+          return;
+        }
+      }
+
       if (event.key === 'Enter' && !event.shiftKey && !isImeConfirm && !isVirtualKbd) {
         event.preventDefault();
         onSubmit();
@@ -149,32 +246,81 @@ export function ComposeInput({
     onRequestEditLastMessage,
     onSubmit,
     textareaRef,
+    formatEnabled,
   ]);
 
+  const toolbarVisible = (() => {
+    if (!formatEnabled) return false;
+    if (isMentionMenuOpen) return false;
+    if (linkMode) return true;
+    return focused && hasSelection && !isComposing;
+  })();
+
+  const [toolbarAnchor, setToolbarAnchor] = useState<FormatToolbarAnchor | null>(null);
+  // Re-measure the anchor after every commit; visibility stays derived from
+  // `toolbarVisible` in the render above, so a stale anchor is ignored while hidden.
+  useLayoutEffect(() => {
+    if (!toolbarVisible) return;
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    const rect = textarea.getBoundingClientRect();
+    const next = { top: rect.top - 8, left: rect.left + rect.width / 2 };
+    setToolbarAnchor((prev) => (prev && prev.top === next.top && prev.left === next.left ? prev : next));
+  }, [toolbarVisible, text, textareaRef]);
+
   return (
-    <div className={styles.inputRow}>
-      <textarea
-        id="messageCompose"
-        ref={textareaRef}
-        className={styles.textarea}
-        placeholder={t`Message`}
-        value={text}
-        rows={1}
-        onChange={(event) => onTextChange(event.target.value)}
-        onFocus={() => onFocusChange?.(true)}
-        onBlur={() => onFocusChange?.(false)}
-        enterKeyHint="enter"
-      />
-      <button
-        type="button"
-        className={`${styles.stickerBtn}${isStickerActive ? ` ${styles.stickerBtnActive}` : ''}`}
-        aria-label={t`Sticker`}
-        aria-pressed={isStickerActive}
-        onClick={onStickerPress}
-        data-sticker-btn
-      >
-        <IonIcon icon={happyOutline} />
-      </button>
-    </div>
+    <>
+      <div className={styles.inputRow}>
+        <textarea
+          id="messageCompose"
+          ref={textareaRef}
+          className={styles.textarea}
+          placeholder={t`Message`}
+          value={text}
+          rows={1}
+          onChange={(event) => onTextChange(event.target.value)}
+          onFocus={() => {
+            setFocusedState(true);
+            measureSelection();
+            onFocusChange?.(true);
+          }}
+          onBlur={() => {
+            setFocusedState(false);
+            onFocusChange?.(false);
+          }}
+          onSelect={measureSelection}
+          onMouseUp={measureSelection}
+          onKeyUp={measureSelection}
+          onCompositionStart={() => setComposing(true)}
+          onCompositionEnd={() => {
+            setComposing(false);
+            measureSelection();
+          }}
+          enterKeyHint="enter"
+        />
+        <button
+          type="button"
+          className={`${styles.stickerBtn}${isStickerActive ? ` ${styles.stickerBtnActive}` : ''}`}
+          aria-label={t`Sticker`}
+          aria-pressed={isStickerActive}
+          onClick={onStickerPress}
+          data-sticker-btn
+        >
+          <IonIcon icon={happyOutline} />
+        </button>
+      </div>
+      {toolbarVisible && toolbarAnchor && typeof document !== 'undefined'
+        ? createPortal(
+            <FormatToolbar
+              anchor={toolbarAnchor}
+              linkMode={linkMode}
+              onRequestLinkMode={requestLinkMode}
+              onFormat={(kind) => applyActionRef.current?.(kind)}
+              onSubmitLink={(url) => applyActionRef.current?.('link', url)}
+            />,
+            document.body,
+          )
+        : null}
+    </>
   );
 }

--- a/wetty-chat-mobile/src/components/chat/compose/FormatToolbar.dom.test.tsx
+++ b/wetty-chat-mobile/src/components/chat/compose/FormatToolbar.dom.test.tsx
@@ -1,0 +1,135 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { FormatToolbar } from './FormatToolbar';
+
+vi.mock('@lingui/core/macro', () => ({
+  t: (strings: TemplateStringsArray | string) => (typeof strings === 'string' ? strings : strings.join('')),
+}));
+vi.mock('@ionic/react', () => ({
+  IonIcon: () => null,
+}));
+vi.mock('ionicons/icons', () => ({
+  linkOutline: 'link-outline',
+}));
+vi.mock('./FormatToolbar.module.scss', () => ({ default: {} }));
+
+let container: HTMLDivElement;
+let root: Root;
+let onFormat: Mock<(kind: 'bold' | 'italic' | 'strike' | 'underline' | 'code' | 'quote') => void>;
+let onSubmitLink: Mock<(url: string) => void>;
+let onRequestLinkMode: Mock<(open: boolean) => void>;
+
+const anchor = { top: 120, left: 300 };
+
+function click(target: Element, eventInit: MouseEventInit = {}) {
+  act(() => {
+    target.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true, ...eventInit }));
+    target.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, ...eventInit }));
+  });
+}
+
+function render(linkMode = false) {
+  act(() => {
+    root.render(
+      <FormatToolbar
+        anchor={anchor}
+        linkMode={linkMode}
+        onRequestLinkMode={onRequestLinkMode}
+        onFormat={onFormat}
+        onSubmitLink={onSubmitLink}
+      />,
+    );
+  });
+}
+
+function typeText(input: HTMLInputElement, value: string) {
+  // Mirrors the native value setter trick used for controlled inputs.
+  const valueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+  act(() => {
+    valueSetter?.call(input, value);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+}
+
+beforeEach(() => {
+  onFormat = vi.fn();
+  onSubmitLink = vi.fn();
+  onRequestLinkMode = vi.fn();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+describe('FormatToolbar', () => {
+  it('renders all seven formatting buttons', () => {
+    render();
+
+    expect(container.querySelector('[data-format-bold]')).toBeTruthy();
+    expect(container.querySelector('[data-format-italic]')).toBeTruthy();
+    expect(container.querySelector('[data-format-strike]')).toBeTruthy();
+    expect(container.querySelector('[data-format-underline]')).toBeTruthy();
+    expect(container.querySelector('[data-format-code]')).toBeTruthy();
+    expect(container.querySelector('[data-format-quote]')).toBeTruthy();
+    expect(container.querySelector('[data-format-link]')).toBeTruthy();
+    expect(container.querySelector('[data-format-url-popup]')).toBeNull();
+  });
+
+  it('keeps textarea selection alive: mousedown on any button does not steal focus', () => {
+    render();
+    const bold = container.querySelector('[data-format-bold]')!;
+
+    let defaultPrevented = false;
+    act(() => {
+      const event = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
+      defaultPrevented = !bold.dispatchEvent(event);
+    });
+
+    // preventDefault on mousedown is what stops the textarea from blurring.
+    expect(defaultPrevented).toBe(true);
+  });
+
+  it('opens the URL popup via the link button', () => {
+    render();
+
+    click(container.querySelector('[data-format-link]')!);
+    expect(onRequestLinkMode).toHaveBeenCalledWith(true);
+  });
+
+  it('submits a typed URL and ignores empty input', () => {
+    render(true);
+
+    const input = container.querySelector('[data-format-url-input]')! as HTMLInputElement;
+    const apply = container.querySelector('[data-format-url-apply]')!;
+
+    typeText(input, 'example.com/path');
+    click(apply);
+    expect(onSubmitLink).toHaveBeenCalledWith('example.com/path');
+    expect(onRequestLinkMode).toHaveBeenCalledWith(false);
+
+    onSubmitLink.mockClear();
+    onRequestLinkMode.mockClear();
+    typeText(input, '   ');
+    click(apply);
+    expect(onSubmitLink).not.toHaveBeenCalled();
+  });
+
+  it('cancels link mode on Escape', () => {
+    render(true);
+    const input = container.querySelector('[data-format-url-input]')! as HTMLInputElement;
+
+    act(() => {
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }));
+    });
+
+    expect(onRequestLinkMode).toHaveBeenCalledWith(false);
+  });
+});

--- a/wetty-chat-mobile/src/components/chat/compose/FormatToolbar.module.scss
+++ b/wetty-chat-mobile/src/components/chat/compose/FormatToolbar.module.scss
@@ -1,0 +1,121 @@
+.toolbar {
+  position: fixed;
+  z-index: 2000;
+  transform: translate(-50%, -100%);
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 4px 6px;
+  background: var(--ion-item-background, var(--ion-background-color, #fff));
+  border: 1px solid var(--ion-background-color-step-150, #e0e0e0);
+  border-radius: 12px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.22);
+}
+
+.button {
+  min-width: 34px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  color: var(--ion-text-color, #222);
+  font-size: 15px;
+  padding: 0 4px;
+
+  &:hover {
+    background: var(--ion-background-color-step-100, #f0f0f0);
+  }
+
+  &:active {
+    background: var(--ion-background-color-step-150, #e0e0e0);
+  }
+}
+
+.boldGlyph {
+  font-weight: 700;
+}
+
+.italicGlyph {
+  font-style: italic;
+  font-family: Georgia, 'Times New Roman', serif;
+}
+
+.strikeGlyph {
+  text-decoration: line-through;
+}
+
+.underlineGlyph {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.codeGlyph {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 13px;
+  letter-spacing: -1px;
+}
+
+.quoteGlyph {
+  font-family: Georgia, 'Times New Roman', serif;
+  font-size: 20px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.linkIcon {
+  font-size: 18px;
+}
+
+.popup {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 6px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px;
+  background: var(--ion-item-background, var(--ion-background-color, #fff));
+  border: 1px solid var(--ion-background-color-step-150, #e0e0e0);
+  border-radius: 10px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.22);
+}
+
+.urlInput {
+  width: 180px;
+  height: 30px;
+  padding: 0 8px;
+  border: 1px solid var(--ion-background-color-step-200, #ddd);
+  border-radius: 8px;
+  outline: none;
+  font-size: 13px;
+  background: var(--ion-background-color, #fff);
+  color: var(--ion-text-color, #222);
+
+  &:focus {
+    border-color: var(--ion-color-primary, #3880ff);
+  }
+}
+
+.popupBtn {
+  height: 30px;
+  min-width: 64px;
+  padding: 0 12px;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 13px;
+  white-space: nowrap;
+  flex-shrink: 0;
+  background: var(--ion-color-primary, #3880ff);
+  color: var(--ion-color-primary-contrast, #fff);
+}
+
+.popupCancel {
+  composes: popupBtn;
+  background: var(--ion-background-color-step-150, #e0e0e0);
+  color: var(--ion-text-color, #222);
+}

--- a/wetty-chat-mobile/src/components/chat/compose/FormatToolbar.tsx
+++ b/wetty-chat-mobile/src/components/chat/compose/FormatToolbar.tsx
@@ -1,0 +1,166 @@
+import { useRef, useState } from 'react';
+import { IonIcon } from '@ionic/react';
+import { t } from '@lingui/core/macro';
+import { linkOutline } from 'ionicons/icons';
+import type { TextFormatKind } from '@/utils/textFormat';
+import styles from './FormatToolbar.module.scss';
+
+/** Viewport-space point the toolbar should hover above (textarea top-centre). */
+export interface FormatToolbarAnchor {
+  top: number;
+  left: number;
+}
+
+interface FormatToolbarProps {
+  anchor: FormatToolbarAnchor;
+  /** Link popup visibility; owned by the composer so the toolbar survives the popup input stealing focus. */
+  linkMode: boolean;
+  onRequestLinkMode: (open: boolean) => void;
+  /** Inline/block formatting actions; `link` is handled via the URL popup. */
+  onFormat: (kind: Exclude<TextFormatKind, 'link'>) => void;
+  /** Raw (still unsanitised) URL typed by the user. */
+  onSubmitLink: (url: string) => void;
+}
+
+/**
+ * Floating formatting pill (bold / italic / strike / underline / code / quote /
+ * link) shown next to the textarea while text is selected. Mousedowns are
+ * prevented from defaulting so the textarea never loses its selection.
+ */
+export function FormatToolbar({ anchor, linkMode, onRequestLinkMode, onFormat, onSubmitLink }: FormatToolbarProps) {
+  const [draftUrl, setDraftUrl] = useState('');
+  const urlInputRef = useRef<HTMLInputElement | null>(null);
+
+  const openLinkMode = () => {
+    setDraftUrl('https://');
+    onRequestLinkMode(true);
+    const focusUrlInput = () => urlInputRef.current?.focus();
+    if (typeof requestAnimationFrame === 'function') {
+      requestAnimationFrame(focusUrlInput);
+    } else {
+      window.setTimeout(focusUrlInput, 0);
+    }
+  };
+
+  const closeLinkMode = () => {
+    onRequestLinkMode(false);
+  };
+
+  const submitLink = () => {
+    const url = draftUrl.trim();
+    if (!url) return;
+    onSubmitLink(url);
+    onRequestLinkMode(false);
+  };
+
+  return (
+    <div
+      className={styles.toolbar}
+      style={{ top: anchor.top, left: anchor.left }}
+      data-format-toolbar
+      onMouseDown={(event) => event.preventDefault()}
+    >
+      <button
+        type="button"
+        className={styles.button}
+        title={t`Bold (Ctrl+B)`}
+        aria-label={t`Bold (Ctrl+B)`}
+        onClick={() => onFormat('bold')}
+        data-format-bold
+      >
+        <span className={styles.boldGlyph}>B</span>
+      </button>
+      <button
+        type="button"
+        className={styles.button}
+        title={t`Italic (Ctrl+I)`}
+        aria-label={t`Italic (Ctrl+I)`}
+        onClick={() => onFormat('italic')}
+        data-format-italic
+      >
+        <span className={styles.italicGlyph}>I</span>
+      </button>
+      <button
+        type="button"
+        className={styles.button}
+        title={t`Strikethrough (Ctrl+D)`}
+        aria-label={t`Strikethrough (Ctrl+D)`}
+        onClick={() => onFormat('strike')}
+        data-format-strike
+      >
+        <span className={styles.strikeGlyph}>S</span>
+      </button>
+      <button
+        type="button"
+        className={styles.button}
+        title={t`Underline (Ctrl+U)`}
+        aria-label={t`Underline (Ctrl+U)`}
+        onClick={() => onFormat('underline')}
+        data-format-underline
+      >
+        <span className={styles.underlineGlyph}>U</span>
+      </button>
+      <button
+        type="button"
+        className={styles.button}
+        title={t`Code block`}
+        aria-label={t`Code block`}
+        onClick={() => onFormat('code')}
+        data-format-code
+      >
+        <span className={styles.codeGlyph}>{'</>'}</span>
+      </button>
+      <button
+        type="button"
+        className={styles.button}
+        title={t`Quote (Ctrl+Q)`}
+        aria-label={t`Quote (Ctrl+Q)`}
+        onClick={() => onFormat('quote')}
+        data-format-quote
+      >
+        <span className={styles.quoteGlyph}>&quot;</span>
+      </button>
+      <button
+        type="button"
+        className={styles.button}
+        title={t`Link`}
+        aria-label={t`Link`}
+        aria-pressed={linkMode}
+        onClick={openLinkMode}
+        data-format-link
+      >
+        <IonIcon icon={linkOutline} className={styles.linkIcon} />
+      </button>
+
+      {linkMode && (
+        <div className={styles.popup} data-format-url-popup>
+          <input
+            ref={urlInputRef}
+            className={styles.urlInput}
+            type="text"
+            inputMode="url"
+            placeholder="https://example.com"
+            value={draftUrl}
+            onChange={(event) => setDraftUrl(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Escape') {
+                event.preventDefault();
+                closeLinkMode();
+              } else if (event.key === 'Enter') {
+                event.preventDefault();
+                submitLink();
+              }
+            }}
+            data-format-url-input
+          />
+          <button type="button" className={styles.popupBtn} onClick={submitLink} data-format-url-apply>
+            {t`Add`}
+          </button>
+          <button type="button" className={styles.popupCancel} onClick={closeLinkMode} data-format-url-cancel>
+            {t`Cancel`}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/wetty-chat-mobile/src/components/chat/compose/MentionWireFormat.dom.test.tsx
+++ b/wetty-chat-mobile/src/components/chat/compose/MentionWireFormat.dom.test.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, type ReactElement } from 'react';
+import { useEffect, useRef, useState, type ReactElement } from 'react';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -46,15 +46,20 @@ function Harness(): ReactElement {
     onTextChange: onMentionTextChange,
   } = useMentionAutocomplete(textareaRef, text, 1);
 
-  selectMentionRef.current = selectMention;
-  sendRef.current = () => {
-    // Mirrors MessageComposeBar.handleSend: convert to wire format first,
-    // then trim so mention offsets are computed against the raw text.
-    const wire = toWireFormat(text).trim();
-    setSent(wire);
-    setText('');
-    clearMentions();
-  };
+  // Expose the mention select action and a send stub (mirroring
+  // MessageComposeBar.handleSend) to the test body. Filled in an effect so
+  // lint's react-hooks/immutability rule stays satisfied.
+  useEffect(() => {
+    selectMentionRef.current = selectMention;
+    sendRef.current = () => {
+      // Mirrors MessageComposeBar.handleSend: convert to wire format first,
+      // then trim so mention offsets are computed against the raw text.
+      const wire = toWireFormat(text).trim();
+      setSent(wire);
+      setText('');
+      clearMentions();
+    };
+  }, [selectMention, toWireFormat, text, clearMentions]);
 
   return (
     <div>

--- a/wetty-chat-mobile/src/components/chat/compose/MentionWireFormat.dom.test.tsx
+++ b/wetty-chat-mobile/src/components/chat/compose/MentionWireFormat.dom.test.tsx
@@ -1,0 +1,211 @@
+import { useRef, useState, type ReactElement } from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getMembers, type MemberResponse } from '@/api/group';
+import { ComposeInput } from './ComposeInput';
+import { useMentionAutocomplete } from './useMentionAutocomplete';
+
+vi.mock('@lingui/core/macro', () => ({
+  t: (strings: TemplateStringsArray | string) => (typeof strings === 'string' ? strings : strings.join('')),
+}));
+vi.mock('@ionic/react', () => ({
+  IonIcon: () => null,
+}));
+vi.mock('ionicons/icons', () => ({
+  happyOutline: 'happy-outline',
+  linkOutline: 'link-outline',
+}));
+vi.mock('./MessageComposeBar.module.scss', () => ({ default: {} }));
+vi.mock('./FormatToolbar.module.scss', () => ({ default: {} }));
+vi.mock('@/features', () => ({
+  isFeatureEnabled: () => true,
+}));
+vi.mock('@/api/group', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/api/group')>();
+  return { ...actual, getMembers: vi.fn() };
+});
+
+const MENTION_MEMBER = { uid: 7, username: 'devuser2' } as MemberResponse;
+const BODY_PORTAL_SELECTOR = '[data-format-toolbar]';
+
+let container: HTMLDivElement;
+let root: Root;
+let selectMentionRef: { current: (member: MemberResponse) => void };
+let sendRef: { current: () => void };
+
+function Harness(): ReactElement {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [text, setText] = useState('');
+  const [sent, setSent] = useState('');
+  const {
+    mentionState,
+    selectMention,
+    toWireFormat,
+    clearMentions,
+    onTextChange: onMentionTextChange,
+  } = useMentionAutocomplete(textareaRef, text, 1);
+
+  selectMentionRef.current = selectMention;
+  sendRef.current = () => {
+    // Mirrors MessageComposeBar.handleSend: convert to wire format first,
+    // then trim so mention offsets are computed against the raw text.
+    const wire = toWireFormat(text).trim();
+    setSent(wire);
+    setText('');
+    clearMentions();
+  };
+
+  return (
+    <div>
+      <ComposeInput
+        textareaRef={textareaRef}
+        text={text}
+        onTextChange={(value) => {
+          setText(value);
+          onMentionTextChange(value);
+        }}
+        onSubmit={sendRef.current}
+        canRequestRecentEdit={false}
+        onRequestEditLastMessage={() => false}
+        isUnchangedEdit={false}
+        onCancelEdit={() => {}}
+        onCancelReply={() => {}}
+        onStickerPress={() => {}}
+        isStickerActive={false}
+        onMentionKeyDown={() => false}
+        isMentionMenuOpen={mentionState.isOpen}
+      />
+      <div data-sent>{sent}</div>
+    </div>
+  );
+}
+
+function textarea(): HTMLTextAreaElement {
+  const el = container.querySelector('textarea');
+  if (!el) throw new Error('textarea not rendered');
+  return el;
+}
+
+function sentText(): string {
+  return container.querySelector('[data-sent]')?.textContent ?? '';
+}
+
+async function settle() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+/** Types text as one native input commit (value + caret), like real typing. */
+async function commitText(next: string, caret: number) {
+  await act(async () => {
+    const ta = textarea();
+    Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')!.set!.call(ta, next);
+    ta.setSelectionRange(caret, caret);
+    ta.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+}
+
+async function focusTextarea() {
+  await act(async () => {
+    textarea().dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+  });
+}
+
+async function selectRange(start: number, end: number) {
+  await act(async () => {
+    const ta = textarea();
+    ta.setSelectionRange(start, end);
+    ta.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+  });
+}
+
+async function flushTimers() {
+  await act(async () => {
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+  });
+}
+
+function toolbar(): HTMLElement | null {
+  return document.body.querySelector(BODY_PORTAL_SELECTOR);
+}
+
+function clickToolbarButton(selector: string) {
+  const target = document.body.querySelector(selector);
+  if (!target) throw new Error(`missing ${selector}`);
+  act(() => {
+    target.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
+    target.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+  });
+}
+
+beforeEach(() => {
+  vi.mocked(getMembers).mockReset();
+  vi.mocked(getMembers).mockResolvedValue({
+    data: { members: [MENTION_MEMBER] },
+    status: 200,
+    statusText: 'OK',
+    headers: {},
+    config: {},
+  } as never);
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+    callback(0);
+    return 0;
+  });
+  selectMentionRef = { current: () => {} };
+  sendRef = { current: () => {} };
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  act(() => {
+    root.render(<Harness />);
+  });
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+  document.body.querySelectorAll(BODY_PORTAL_SELECTOR).forEach((el) => el.remove());
+});
+
+describe('mention autocomplete wire format', () => {
+  it('sends a wire mention after the mention is wrapped in emphasis markers', async () => {
+    await commitText('@devuser2', 9);
+    await settle();
+    await act(async () => {
+      selectMentionRef.current(MENTION_MEMBER);
+    });
+    expect(textarea().value).toBe('@devuser2 ');
+
+    await focusTextarea();
+    await selectRange(0, 9);
+    expect(toolbar()).not.toBeNull();
+    clickToolbarButton('[data-format-italic]');
+    await flushTimers();
+    expect(textarea().value).toBe('*@devuser2* ');
+
+    await act(async () => {
+      sendRef.current();
+    });
+    expect(sentText()).toBe('*@[uid:7]*');
+  });
+
+  it('trims leading whitespace after converting to the wire format', async () => {
+    // Mention after a leading space — offsets start at 1, not 0.
+    await commitText(' @devuser2', 10);
+    await settle();
+    await act(async () => {
+      selectMentionRef.current(MENTION_MEMBER);
+    });
+    expect(textarea().value).toBe(' @devuser2 ');
+
+    await act(async () => {
+      sendRef.current();
+    });
+    expect(sentText()).toBe('@[uid:7]');
+  });
+});

--- a/wetty-chat-mobile/src/components/chat/compose/MessageComposeBar.tsx
+++ b/wetty-chat-mobile/src/components/chat/compose/MessageComposeBar.tsx
@@ -188,7 +188,8 @@ const MessageComposeBarInner = forwardRef<MessageComposeBarHandle, MessageCompos
     }, [resizeTextarea, text]);
 
     const handleSend = useCallback(() => {
-      const trimmed = toWireFormat(text.trim());
+      // Wire-format first: entry offsets index the untrimmed text.
+      const trimmed = toWireFormat(text).trim();
       const uploadedRecords = uploads.filter(
         (record) => record.state.status === 'uploaded' && Boolean(record.state.attachmentId),
       );
@@ -475,6 +476,7 @@ const MessageComposeBarInner = forwardRef<MessageComposeBarHandle, MessageCompos
                 onStickerPress={editing ? undefined : handleStickerPress}
                 isStickerActive={!editing && stickerPickerOpen}
                 onMentionKeyDown={handleMentionKeyDown}
+                isMentionMenuOpen={mentionState.isOpen}
               />
             )}
           </div>

--- a/wetty-chat-mobile/src/components/chat/compose/useMentionAutocomplete.test.ts
+++ b/wetty-chat-mobile/src/components/chat/compose/useMentionAutocomplete.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import {
+  mentionEntriesToWire,
+  relocateMentionEntries,
+  type MentionEntry,
+} from './useMentionAutocomplete';
+
+const entry = (start: number, end: number, username = 'devuser2', uid = 7): MentionEntry => ({
+  uid,
+  username,
+  start,
+  end,
+});
+
+describe('relocateMentionEntries', () => {
+  it('keeps an entry unchanged when text is appended after it', () => {
+    expect(relocateMentionEntries('@devuser2', [entry(0, 9)], '@devuser2!')).toEqual([entry(0, 9)]);
+  });
+
+  it('shifts an entry forward when characters are inserted before it', () => {
+    expect(relocateMentionEntries('Hi @devuser2', [entry(3, 12)], 'Hi *@devuser2')).toEqual([
+      entry(4, 13),
+    ]);
+  });
+
+  it('shifts an entry backward when text before it is deleted', () => {
+    expect(relocateMentionEntries('Hi @devuser2 world', [entry(3, 12)], '@devuser2 world')).toEqual([
+      entry(0, 9),
+    ]);
+  });
+
+  it('re-locates an entry wrapped in bold/italic/strike markers', () => {
+    expect(relocateMentionEntries('@devuser2 ', [entry(0, 9)], '**@devuser2** ')).toEqual([
+      entry(2, 11),
+    ]);
+    expect(relocateMentionEntries('@devuser2 ', [entry(0, 9)], '*@devuser2* ')).toEqual([
+      entry(1, 10),
+    ]);
+    expect(relocateMentionEntries('@devuser2 ', [entry(0, 9)], '~~@devuser2~~ ')).toEqual([
+      entry(2, 11),
+    ]);
+  });
+
+  it('re-locates an entry when a marker is inserted only before it', () => {
+    expect(relocateMentionEntries('@devuser2 ', [entry(0, 9)], '*@devuser2 ')).toEqual([
+      entry(1, 10),
+    ]);
+  });
+
+  it('drops the entry when the mention text itself is edited', () => {
+    expect(relocateMentionEntries('@devuser2', [entry(0, 9)], '@devxuser2')).toEqual([]);
+    expect(relocateMentionEntries('@devuser2', [entry(0, 9)], '@devus')).toEqual([]);
+    expect(relocateMentionEntries('@devuser2', [entry(0, 9)], '@devuserx2')).toEqual([]);
+  });
+
+  it('shifts several entries independently across one edit', () => {
+    const previous = '@alice see @bob now';
+    const before: MentionEntry[] = [
+      entry(0, 6, 'alice', 1),
+      entry(11, 15, 'bob', 2),
+    ];
+    const next = '**@alice** see @bob now';
+    expect(relocateMentionEntries(previous, before, next)).toEqual([
+      entry(2, 8, 'alice', 1),
+      entry(15, 19, 'bob', 2),
+    ]);
+  });
+
+  it('returns the same array reference when nothing changed', () => {
+    const before = [entry(0, 9)];
+    expect(relocateMentionEntries('@devuser2', before, '@devuser2')).toBe(before);
+  });
+
+  it('returns the same array reference when there are no entries', () => {
+    expect(relocateMentionEntries('a b', [], 'a * b')).toEqual([]);
+  });
+});
+
+describe('mentionEntriesToWire', () => {
+  it('replaces a plain mention with the wire macro', () => {
+    expect(mentionEntriesToWire('@devuser2 hello', [entry(0, 9)])).toBe('@[uid:7] hello');
+  });
+
+  it('replaces mentions that sit inside markdown emphasis markers', () => {
+    expect(mentionEntriesToWire('*@devuser2* today', [entry(1, 10)])).toBe('*@[uid:7]* today');
+    expect(mentionEntriesToWire('**@devuser2** today', [entry(2, 11)])).toBe('**@[uid:7]** today');
+    expect(mentionEntriesToWire('~~@devuser2~~ today', [entry(2, 11)])).toBe('~~@[uid:7]~~ today');
+    expect(mentionEntriesToWire('__@devuser2__ today', [entry(2, 11)])).toBe('__@[uid:7]__ today');
+  });
+
+  it('replaces several mentions in one pass', () => {
+    const text = '@alice and @bob';
+    const entries = [entry(0, 6, 'alice', 1), entry(11, 15, 'bob', 2)];
+    expect(mentionEntriesToWire(text, entries)).toBe('@[uid:1] and @[uid:2]');
+  });
+
+  it('leaves mentions inside code regions verbatim', () => {
+    const fenced = '```\n@devuser2\n```';
+    expect(mentionEntriesToWire(fenced, [entry(4, 13)])).toBe(fenced);
+    const inline = 'run `@devuser2` now';
+    expect(mentionEntriesToWire(inline, [entry(5, 14)])).toBe(inline);
+  });
+
+  it('leaves a mention alone when its offsets no longer match the text', () => {
+    expect(mentionEntriesToWire('@devuser2 ', [entry(1, 10)])).toBe('@devuser2 ');
+  });
+
+  it('keeps leading/trailing whitespace when converting (caller trims after)', () => {
+    expect(mentionEntriesToWire('  @devuser2 ', [entry(2, 11)])).toBe('  @[uid:7] ');
+  });
+
+  it('returns the original text when there are no entries', () => {
+    expect(mentionEntriesToWire('plain text', [])).toBe('plain text');
+  });
+});

--- a/wetty-chat-mobile/src/components/chat/compose/useMentionAutocomplete.test.ts
+++ b/wetty-chat-mobile/src/components/chat/compose/useMentionAutocomplete.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import {
-  mentionEntriesToWire,
-  relocateMentionEntries,
-  type MentionEntry,
-} from './useMentionAutocomplete';
+import { mentionEntriesToWire, relocateMentionEntries, type MentionEntry } from './useMentionAutocomplete';
 
 const entry = (start: number, end: number, username = 'devuser2', uid = 7): MentionEntry => ({
   uid,
@@ -18,33 +14,21 @@ describe('relocateMentionEntries', () => {
   });
 
   it('shifts an entry forward when characters are inserted before it', () => {
-    expect(relocateMentionEntries('Hi @devuser2', [entry(3, 12)], 'Hi *@devuser2')).toEqual([
-      entry(4, 13),
-    ]);
+    expect(relocateMentionEntries('Hi @devuser2', [entry(3, 12)], 'Hi *@devuser2')).toEqual([entry(4, 13)]);
   });
 
   it('shifts an entry backward when text before it is deleted', () => {
-    expect(relocateMentionEntries('Hi @devuser2 world', [entry(3, 12)], '@devuser2 world')).toEqual([
-      entry(0, 9),
-    ]);
+    expect(relocateMentionEntries('Hi @devuser2 world', [entry(3, 12)], '@devuser2 world')).toEqual([entry(0, 9)]);
   });
 
   it('re-locates an entry wrapped in bold/italic/strike markers', () => {
-    expect(relocateMentionEntries('@devuser2 ', [entry(0, 9)], '**@devuser2** ')).toEqual([
-      entry(2, 11),
-    ]);
-    expect(relocateMentionEntries('@devuser2 ', [entry(0, 9)], '*@devuser2* ')).toEqual([
-      entry(1, 10),
-    ]);
-    expect(relocateMentionEntries('@devuser2 ', [entry(0, 9)], '~~@devuser2~~ ')).toEqual([
-      entry(2, 11),
-    ]);
+    expect(relocateMentionEntries('@devuser2 ', [entry(0, 9)], '**@devuser2** ')).toEqual([entry(2, 11)]);
+    expect(relocateMentionEntries('@devuser2 ', [entry(0, 9)], '*@devuser2* ')).toEqual([entry(1, 10)]);
+    expect(relocateMentionEntries('@devuser2 ', [entry(0, 9)], '~~@devuser2~~ ')).toEqual([entry(2, 11)]);
   });
 
   it('re-locates an entry when a marker is inserted only before it', () => {
-    expect(relocateMentionEntries('@devuser2 ', [entry(0, 9)], '*@devuser2 ')).toEqual([
-      entry(1, 10),
-    ]);
+    expect(relocateMentionEntries('@devuser2 ', [entry(0, 9)], '*@devuser2 ')).toEqual([entry(1, 10)]);
   });
 
   it('drops the entry when the mention text itself is edited', () => {
@@ -55,15 +39,9 @@ describe('relocateMentionEntries', () => {
 
   it('shifts several entries independently across one edit', () => {
     const previous = '@alice see @bob now';
-    const before: MentionEntry[] = [
-      entry(0, 6, 'alice', 1),
-      entry(11, 15, 'bob', 2),
-    ];
+    const before: MentionEntry[] = [entry(0, 6, 'alice', 1), entry(11, 15, 'bob', 2)];
     const next = '**@alice** see @bob now';
-    expect(relocateMentionEntries(previous, before, next)).toEqual([
-      entry(2, 8, 'alice', 1),
-      entry(15, 19, 'bob', 2),
-    ]);
+    expect(relocateMentionEntries(previous, before, next)).toEqual([entry(2, 8, 'alice', 1), entry(15, 19, 'bob', 2)]);
   });
 
   it('returns the same array reference when nothing changed', () => {

--- a/wetty-chat-mobile/src/components/chat/compose/useMentionAutocomplete.ts
+++ b/wetty-chat-mobile/src/components/chat/compose/useMentionAutocomplete.ts
@@ -78,7 +78,10 @@ export function relocateMentionEntries(
   let prefix = 0;
   while (prefix < maxAnchor && previousText[prefix] === nextText[prefix]) prefix += 1;
   let suffix = 0;
-  while (suffix < maxAnchor - prefix && previousText[previousText.length - 1 - suffix] === nextText[nextText.length - 1 - suffix]) {
+  while (
+    suffix < maxAnchor - prefix &&
+    previousText[previousText.length - 1 - suffix] === nextText[nextText.length - 1 - suffix]
+  ) {
     suffix += 1;
   }
 
@@ -204,9 +207,7 @@ export function useMentionAutocomplete(
 
   const onTextChange = useCallback(
     (newText: string) => {
-      setMentionEntries((prev) =>
-        prev.length === 0 ? prev : relocateMentionEntries(text, prev, newText),
-      );
+      setMentionEntries((prev) => (prev.length === 0 ? prev : relocateMentionEntries(text, prev, newText)));
 
       const ta = textareaRef.current;
       if (!ta) {

--- a/wetty-chat-mobile/src/components/chat/compose/useMentionAutocomplete.ts
+++ b/wetty-chat-mobile/src/components/chat/compose/useMentionAutocomplete.ts
@@ -1,5 +1,6 @@
 import { useCallback, useRef, useState } from 'react';
 import { getMembers, type MemberResponse } from '@/api/group';
+import { findCodeRegions } from '@/utils/markdown/codeRegions';
 
 export interface MentionEntry {
   uid: number;
@@ -57,6 +58,97 @@ function detectMentionTrigger(text: string, cursorPos: number): { query: string;
   return null;
 }
 
+/**
+ * Re-anchors mention entries (stored as absolute offsets into `previousText`)
+ * after the text has been edited into `nextText`.
+ *
+ * Edits that happen entirely before or after an entry shift its offsets;
+ * edits that touch the mention's own span drop it — unless the mention text
+ * survives verbatim inside the rewritten middle (e.g. wrapping `*@alice*` in
+ * emphasis), in which case the entry is re-located by searching for the text.
+ */
+export function relocateMentionEntries(
+  previousText: string,
+  entries: MentionEntry[],
+  nextText: string,
+): MentionEntry[] {
+  if (entries.length === 0 || previousText === nextText) return entries;
+
+  const maxAnchor = Math.min(previousText.length, nextText.length);
+  let prefix = 0;
+  while (prefix < maxAnchor && previousText[prefix] === nextText[prefix]) prefix += 1;
+  let suffix = 0;
+  while (suffix < maxAnchor - prefix && previousText[previousText.length - 1 - suffix] === nextText[nextText.length - 1 - suffix]) {
+    suffix += 1;
+  }
+
+  const changeStart = prefix;
+  const changeEnd = previousText.length - suffix;
+  const delta = nextText.length - previousText.length;
+  const changedNew = nextText.slice(changeStart, nextText.length - suffix);
+
+  const relocated: MentionEntry[] = [];
+  for (const entry of entries) {
+    if (entry.end <= changeStart) {
+      relocated.push(entry);
+      continue;
+    }
+    if (entry.start >= changeEnd) {
+      relocated.push({ ...entry, start: entry.start + delta, end: entry.end + delta });
+      continue;
+    }
+    if (entry.start >= changeStart && entry.end <= changeEnd) {
+      const raw = previousText.slice(entry.start, entry.end);
+      if (raw === `@${entry.username}`) {
+        const hint = entry.start - changeStart;
+        const found = indexOfClosestSubstring(changedNew, raw, hint);
+        if (found !== -1) {
+          relocated.push({ ...entry, start: changeStart + found, end: changeStart + found + raw.length });
+          continue;
+        }
+      }
+    }
+  }
+  return relocated;
+}
+
+function indexOfClosestSubstring(haystack: string, needle: string, hint: number): number {
+  let best = -1;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  let index = haystack.indexOf(needle);
+  while (index !== -1) {
+    const distance = Math.abs(index - hint);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      best = index;
+    }
+    index = haystack.indexOf(needle, index + 1);
+  }
+  return best;
+}
+
+/**
+ * Replaces every valid mention entry in display text with its `@[uid:N]` wire
+ * macro. Mentions whose text no longer matches the entry (edited away), or
+ * that fall inside a code region, are left verbatim — a code mention renders
+ * as plain text and must never trigger a backend reminder.
+ */
+export function mentionEntriesToWire(text: string, entries: MentionEntry[]): string {
+  if (entries.length === 0) return text;
+
+  const codeRegions = findCodeRegions(text);
+  const sorted = [...entries].sort((a, b) => b.start - a.start);
+  let result = text;
+
+  for (const entry of sorted) {
+    if (entry.start < 0 || entry.end > result.length) continue;
+    if (codeRegions.some((region) => entry.start >= region.start && entry.start < region.end)) continue;
+    if (result.slice(entry.start, entry.end) !== `@${entry.username}`) continue;
+    result = `${result.slice(0, entry.start)}@[uid:${entry.uid}]${result.slice(entry.end)}`;
+  }
+  return result;
+}
+
 export function useMentionAutocomplete(
   textareaRef: React.RefObject<HTMLTextAreaElement | null>,
   text: string,
@@ -112,15 +204,9 @@ export function useMentionAutocomplete(
 
   const onTextChange = useCallback(
     (newText: string) => {
-      // Invalidate mention entries if user edited inside a mention
-      setMentionEntries((prev) => {
-        if (prev.length === 0) return prev;
-        const filtered = prev.filter((entry) => {
-          const slice = newText.slice(entry.start, entry.end);
-          return slice === `@${entry.username}`;
-        });
-        return filtered.length === prev.length ? prev : filtered;
-      });
+      setMentionEntries((prev) =>
+        prev.length === 0 ? prev : relocateMentionEntries(text, prev, newText),
+      );
 
       const ta = textareaRef.current;
       if (!ta) {
@@ -128,7 +214,7 @@ export function useMentionAutocomplete(
         return;
       }
 
-      // Use a microtask to read selectionStart after React has flushed the value
+      // Microtask so the cursor is read after React flushed the value.
       queueMicrotask(() => {
         const cursorPos = ta.selectionStart;
         const trigger = detectMentionTrigger(newText, cursorPos);
@@ -148,7 +234,7 @@ export function useMentionAutocomplete(
         debounceRef.current = setTimeout(() => fetchMembers(trigger.query), 250);
       });
     },
-    [closeMention, fetchMembers, textareaRef],
+    [closeMention, fetchMembers, text, textareaRef],
   );
 
   const selectMention = useCallback(
@@ -250,22 +336,7 @@ export function useMentionAutocomplete(
   );
 
   const toWireFormat = useCallback(
-    (displayText: string): string => {
-      if (mentionEntries.length === 0) return displayText;
-
-      let result = displayText;
-
-      // Sort entries by start position descending so replacements don't shift offsets
-      const sorted = [...mentionEntries].sort((a, b) => b.start - a.start);
-      for (const entry of sorted) {
-        const displayMention = `@${entry.username}`;
-        const slice = result.slice(entry.start, entry.end);
-        if (slice === displayMention) {
-          result = result.slice(0, entry.start) + `@[uid:${entry.uid}]` + result.slice(entry.end);
-        }
-      }
-      return result;
-    },
+    (displayText: string): string => mentionEntriesToWire(displayText, mentionEntries),
     [mentionEntries],
   );
 

--- a/wetty-chat-mobile/src/components/chat/lists/ChatList.tsx
+++ b/wetty-chat-mobile/src/components/chat/lists/ChatList.tsx
@@ -70,6 +70,7 @@ import { syncAppBadgeCount } from '@/utils/badges';
 import { getChatDisplayName } from '@/utils/chatDisplay';
 import { UserAvatar } from '@/components/UserAvatar';
 import { formatMessagePreview, getNotificationPreviewLabels, truncatePreview } from '@/utils/messagePreview';
+import { MarkdownSummaryText } from '@/components/chat/previews/MarkdownSummaryText';
 import { getAllDrafts } from '@/utils/draftSync';
 import { onDraftChange } from '@/utils/draftEvents';
 import type { AppDispatch, RootState } from '@/store';
@@ -119,10 +120,11 @@ function getMessagePreview(message: MessagePreview | null, locale: string, showS
   if (!message) return t`No messages yet`;
 
   const previewText = formatMessagePreview(message, getNotificationPreviewLabels(locale));
+  const preview = previewText ? <MarkdownSummaryText text={previewText} /> : t`New message`;
 
   // DM rows omit the sender name — the row title already names the peer.
   if (!showSender) {
-    return previewText || t`New message`;
+    return preview;
   }
 
   const senderName = message.sender?.name || 'User';
@@ -130,7 +132,7 @@ function getMessagePreview(message: MessagePreview | null, locale: string, showS
   return (
     <>
       <span className={styles.chatsListPreviewSender}>{senderName}: </span>
-      {previewText || t`New message`}
+      {preview}
     </>
   );
 }

--- a/wetty-chat-mobile/src/components/chat/lists/ThreadListRow.tsx
+++ b/wetty-chat-mobile/src/components/chat/lists/ThreadListRow.tsx
@@ -11,6 +11,7 @@ import { selectChatMeta } from '@/store/chatsSlice';
 import type { RootState } from '@/store/index';
 import { selectLatestThreadReplyMessage } from '@/store/messages/selectors';
 import { formatMessagePreview, getNotificationPreviewLabels, truncatePreview } from '@/utils/messagePreview';
+import { MarkdownSummaryText } from '@/components/chat/previews/MarkdownSummaryText';
 import styles from './ThreadListRow.module.scss';
 
 function formatRelativeTime(isoString: string, locale: string): string {
@@ -111,7 +112,9 @@ export function ThreadListRow({ thread, locale, isActive, draftText, onSelect, e
       </span>
       <IonLabel className={styles.bodyContent}>
         {/* Row 2: replied to */}
-        <div className={styles.repliedTo}>{rootPreview || (isDm ? null : rootMsg.sender.name)}</div>
+        <div className={styles.repliedTo}>
+          {rootPreview ? <MarkdownSummaryText text={rootPreview} /> : isDm ? null : rootMsg.sender.name}
+        </div>
         {/* Row 3: latest reply or draft */}
         {draftText !== undefined ? (
           <p className={styles.latestReply}>
@@ -123,7 +126,7 @@ export function ThreadListRow({ thread, locale, isActive, draftText, onSelect, e
           lastReplyPreview && (
             <p className={styles.latestReply}>
               {!isDm && <span className={styles.latestReplySender}>{lastReply.sender.name ?? 'User'}:</span>}{' '}
-              {lastReplyPreview}
+              <MarkdownSummaryText text={lastReplyPreview} />
             </p>
           )
         )}

--- a/wetty-chat-mobile/src/components/chat/messages/ChatBubble.module.scss
+++ b/wetty-chat-mobile/src/components/chat/messages/ChatBubble.module.scss
@@ -645,3 +645,145 @@
 .sent .bubble .mentionSelf {
   background: rgba(var(--ion-color-primary-contrast-rgb, 255, 255, 255), 0.28);
 }
+
+/* ===== Markdown-rendered message bodies ===== */
+
+.markdownBody {
+  min-width: 0;
+  word-break: break-word;
+  white-space: pre-wrap;
+
+  p {
+    margin: 0;
+  }
+
+  p + p {
+    margin-top: 6px;
+  }
+
+  > * + * {
+    margin-top: 6px;
+  }
+
+  code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, 'Liberation Mono', monospace;
+    font-size: 0.92em;
+    border-radius: 4px;
+    padding: 0.5px 4px;
+    word-break: break-all;
+  }
+
+  a {
+    color: inherit;
+    text-decoration: underline;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-weight: 600;
+    margin: 0 0 2px;
+    line-height: 1.3;
+  }
+
+  h1 {
+    font-size: 1.45em;
+  }
+
+  h2 {
+    font-size: 1.3em;
+  }
+
+  h3 {
+    font-size: 1.18em;
+  }
+
+  h4 {
+    font-size: 1.08em;
+  }
+
+  h5,
+  h6 {
+    font-size: 1em;
+  }
+
+  blockquote {
+    margin: 4px 0;
+    padding-left: 8px;
+  }
+
+  ul,
+  ol {
+    margin: 2px 0;
+    padding-left: 22px;
+  }
+
+  li > p {
+    margin: 0;
+  }
+
+  hr {
+    border: none;
+    height: 1px;
+    margin: 6px 0;
+    background: currentColor;
+    opacity: 0.25;
+  }
+
+  pre {
+    margin: 6px 0;
+    padding: 8px 10px;
+    border-radius: 8px;
+    overflow-x: auto;
+    font-size: 0.92em;
+
+    code {
+      display: block;
+      padding: 0;
+      background: none;
+      white-space: pre;
+      word-break: normal;
+    }
+  }
+}
+
+// Block-level Markdown (headings/lists/quotes/code/hr/multi-paragraph) claims
+// its own flex line so the timestamp wraps below instead of fighting for space.
+.markdownBlocks {
+  flex-basis: 100%;
+  min-width: 0;
+}
+
+// Code tint & quote accents per bubble theme. Received bubbles use the text /
+// primary palette; sent bubbles are primary-colored, so accents must come from
+// the contrast color to stay legible on the brand background.
+.received .bubble .markdownBody {
+  code {
+    background: rgba(var(--ion-text-color-rgb, 26, 26, 26), 0.08);
+  }
+
+  pre {
+    background: rgba(var(--ion-text-color-rgb, 26, 26, 26), 0.06);
+  }
+
+  blockquote {
+    border-left: 3px solid rgba(var(--ion-color-primary-rgb, 56, 128, 255), 0.5);
+  }
+}
+
+.sent .bubble .markdownBody {
+  code {
+    background: rgba(var(--ion-color-primary-contrast-rgb, 255, 255, 255), 0.16);
+  }
+
+  pre {
+    background: rgba(var(--ion-color-primary-contrast-rgb, 255, 255, 255), 0.12);
+  }
+
+  blockquote {
+    border-left: 3px solid rgba(var(--ion-color-primary-contrast-rgb, 255, 255, 255), 0.6);
+  }
+}

--- a/wetty-chat-mobile/src/components/chat/messages/ChatBubbleBase.dom.test.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/ChatBubbleBase.dom.test.tsx
@@ -1,0 +1,70 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import bubbleStyles from './ChatBubble.module.scss';
+import { ChatBubbleBase, type ChatBubbleBaseProps } from './ChatBubbleBase';
+
+vi.mock('react-redux', () => ({
+  useSelector: (selector: (state: unknown) => unknown) => selector(undefined),
+}));
+
+vi.mock('@/store/settingsSlice', () => ({
+  selectChatFontSizeStyle: () => '14px',
+}));
+
+vi.mock('@/hooks/platformHooks', () => ({
+  useIsDarkMode: () => false,
+  useMouseDetected: () => false,
+}));
+
+vi.mock('@ionic/react', () => ({
+  IonIcon: () => null,
+  isPlatform: () => false,
+}));
+
+vi.mock('@lingui/core/macro', () => ({
+  t: (strings: TemplateStringsArray | string) => (Array.isArray(strings) ? strings.join('') : strings),
+}));
+
+vi.mock('./VoiceMessageBubble', () => ({
+  VoiceMessageBubble: () => null,
+}));
+
+function renderBubble(overrides: Partial<ChatBubbleBaseProps>): string {
+  return renderToStaticMarkup(
+    createElement(ChatBubbleBase, {
+      message: '',
+      senderName: 'Alice',
+      isSent: false,
+      layout: 'bubble-only',
+      showName: false,
+      showAvatar: false,
+      mentions: [],
+      currentUserUid: null,
+      ...overrides,
+    }),
+  );
+}
+
+describe('ChatBubbleBase — Markdown bodies', () => {
+  it('renders block-level Markdown in a block container without width measurement', () => {
+    const html = renderBubble({ message: '# Title\n\nline two **bold**' });
+
+    expect(html).toContain(bubbleStyles.markdownBody);
+    expect(html).toContain(bubbleStyles.markdownBlocks);
+    // Headings are out of the subset: '# Title' renders as literal paragraph text.
+    expect(html).toContain('<p># Title</p>');
+    expect(html).not.toContain('<h1');
+    expect(html).toContain('<strong>bold</strong>');
+    // Character-width layout only applies to legacy text bodies.
+    expect(html).not.toContain('style="width:');
+  });
+
+  it('keeps plain-text messages on the legacy body path', () => {
+    const html = renderBubble({ message: 'Hello there' });
+
+    expect(html).toContain(bubbleStyles.messageText);
+    expect(html).not.toContain(bubbleStyles.markdownBody);
+    expect(html).not.toContain('<p>');
+  });
+});

--- a/wetty-chat-mobile/src/components/chat/messages/ChatBubbleBase.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/ChatBubbleBase.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState, type CSSProperties, type HTMLAttributes, type Ref } 
 import { IonIcon } from '@ionic/react';
 import { chatbubbles, checkmarkCircle, checkmarkCircleOutline, femaleOutline, maleOutline } from 'ionicons/icons';
 import { t } from '@lingui/core/macro';
+import { isFeatureEnabled } from '@/features';
 import { useSelector } from 'react-redux';
 import styles from './ChatBubble.module.scss';
 import { HoverReplyButton } from './HoverReplyButton';
@@ -16,7 +17,7 @@ import { ReplyPreview } from './ReplyPreview';
 import { useIsDarkMode, useMouseDetected } from '@/hooks/platformHooks';
 import { colorForUser } from '@/utils/userColor';
 import { VoiceMessageBubble } from './VoiceMessageBubble';
-import { renderMessageContent } from './messageContent';
+import { renderMessageContentLegacy, prepareMessageContent } from './messageContent';
 import { ReactionPill } from './ReactionPill';
 import { SingleMediaAttachment } from './media/SingleMediaAttachment';
 import { JustifiedMediaGallery } from './media/JustifiedMediaGallery';
@@ -122,8 +123,20 @@ export function ChatBubbleBase({
 
   const baseFont = getChatBaseFont(chatFontSizeStyle as string);
 
+  // Single-parse Markdown analysis, gated by the `messageMarkdown` feature flag.
+  const prepared = useMemo(() => {
+    if (messageType === 'text' && hasBottomContent && isFeatureEnabled('messageMarkdown')) {
+      return prepareMessageContent(message, mentions, currentUserUid, interactive ? onMentionClick : undefined);
+    }
+    return undefined;
+  }, [messageType, hasBottomContent, message, mentions, currentUserUid, interactive, onMentionClick]);
+
+  const markdownNodes = prepared?.isMarkdown ? prepared.nodes : null;
+  const markdownHasBlocks = prepared?.isMarkdown === true && prepared.hasBlocks === true;
+
   const layoutStats = useMemo(() => {
-    if (messageType === 'text' && hasBottomContent) {
+    // Char-width measurement only applies to legacy plain-text bodies.
+    if (messageType === 'text' && hasBottomContent && !prepared?.isMarkdown) {
       try {
         const items = parseChatBubbleContentToRichItems(message, mentions, baseFont);
         return getMessageLayoutStats(items, getChatBubbleMaxWidth());
@@ -132,7 +145,7 @@ export function ChatBubbleBase({
       }
     }
     return undefined;
-  }, [messageType, hasBottomContent, message, mentions, baseFont]);
+  }, [messageType, hasBottomContent, message, mentions, baseFont, prepared]);
 
   const mediaContainerClasses = [
     styles.attachmentsContainer,
@@ -305,11 +318,23 @@ export function ChatBubbleBase({
               : undefined
           }
         >
-          {hasBottomContent && (
-            <span className={styles.messageText}>
-              {renderMessageContent(message, mentions, currentUserUid, interactive ? onMentionClick : undefined)}
-            </span>
-          )}
+          {hasBottomContent &&
+            (markdownNodes ? (
+              <div
+                className={`${styles.markdownBody}${markdownHasBlocks ? ` ${styles.markdownBlocks}` : ''}`}
+              >
+                {markdownNodes}
+              </div>
+            ) : (
+              <span className={styles.messageText}>
+                {renderMessageContentLegacy(
+                  message,
+                  mentions,
+                  currentUserUid,
+                  interactive ? onMentionClick : undefined,
+                )}
+              </span>
+            ))}
           <span className={styles.timestampSpacer} />
           {timestamp && (
             <span className={styles.timestamp}>

--- a/wetty-chat-mobile/src/components/chat/messages/ChatBubbleBase.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/ChatBubbleBase.tsx
@@ -320,9 +320,7 @@ export function ChatBubbleBase({
         >
           {hasBottomContent &&
             (markdownNodes ? (
-              <div
-                className={`${styles.markdownBody}${markdownHasBlocks ? ` ${styles.markdownBlocks}` : ''}`}
-              >
+              <div className={`${styles.markdownBody}${markdownHasBlocks ? ` ${styles.markdownBlocks}` : ''}`}>
                 {markdownNodes}
               </div>
             ) : (

--- a/wetty-chat-mobile/src/components/chat/messages/ReplyPreview.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/ReplyPreview.tsx
@@ -40,9 +40,7 @@ export function ReplyPreview({ replyTo, isSent, interactive, onReplyTap }: Reply
         {replyTo.senderName}
       </div>
       <div className={styles.replyPreviewText}>
-        <MarkdownSummaryText
-          text={formatMessagePreview(replyTo.preview, getNotificationPreviewLabels(locale))}
-        />
+        <MarkdownSummaryText text={formatMessagePreview(replyTo.preview, getNotificationPreviewLabels(locale))} />
       </div>
     </div>
   );

--- a/wetty-chat-mobile/src/components/chat/messages/ReplyPreview.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/ReplyPreview.tsx
@@ -1,5 +1,6 @@
 import { useSelector } from 'react-redux';
 import { formatMessagePreview, type PreviewMessage, getNotificationPreviewLabels } from '@/utils/messagePreview';
+import { MarkdownSummaryText } from '@/components/chat/previews/MarkdownSummaryText';
 import { useIsDarkMode } from '@/hooks/platformHooks';
 import { selectEffectiveLocale } from '@/store/settingsSlice';
 import { colorForUser } from '@/utils/userColor';
@@ -39,7 +40,9 @@ export function ReplyPreview({ replyTo, isSent, interactive, onReplyTap }: Reply
         {replyTo.senderName}
       </div>
       <div className={styles.replyPreviewText}>
-        {formatMessagePreview(replyTo.preview, getNotificationPreviewLabels(locale))}
+        <MarkdownSummaryText
+          text={formatMessagePreview(replyTo.preview, getNotificationPreviewLabels(locale))}
+        />
       </div>
     </div>
   );

--- a/wetty-chat-mobile/src/components/chat/messages/messageContent.dom.test.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/messageContent.dom.test.tsx
@@ -46,3 +46,51 @@ describe('renderMessageContent', () => {
     expect(html).toContain('data-kind="permalink"');
   });
 });
+
+describe('renderMessageContent — Markdown support', () => {
+  const render = (message: string, mentions: { uid: number; username: string; gender: number }[] = []) =>
+    renderToStaticMarkup(
+      <>{renderMessageContent(message, mentions, mentions[0]?.uid ?? null, mentions.length ? vi.fn() : undefined)}</>,
+    );
+
+  it('restores mentions nested inside Markdown emphasis', () => {
+    const html = render('See **@[uid:7]** now', [{ uid: 7, username: 'Alice', gender: 0 }]);
+    expect(html).toContain('@Alice');
+    expect(html).toContain('<strong>');
+    expect(html.indexOf('@Alice')).toBeGreaterThan(html.indexOf('<strong>'));
+  });
+
+  it('italicizes a mention when a stray space precedes the closing `*`', () => {
+    // `*@devuser2 *` was the failing manual-test input: the space on the inner
+    // side of the closing star kept the pair literal under CommonMark.
+    const html = render('*@[uid:7] *', [{ uid: 7, username: 'Alice', gender: 0 }]);
+    expect(html).toContain('<em>');
+    expect(html).toContain('@Alice');
+    expect(html.indexOf('@Alice')).toBeGreaterThan(html.indexOf('<em>'));
+  });
+
+  it('keeps mentions inside code verbatim but restores mentions outside', () => {
+    const html = render('`keep @[uid:8]` and @[uid:9]', [
+      { uid: 8, username: 'Bob', gender: 0 },
+      { uid: 9, username: 'Carol', gender: 0 },
+    ]);
+    expect(html).toContain('<code>keep @[uid:8]</code>');
+    expect(html).not.toContain('@Bob');
+    expect(html).toContain('@Carol');
+  });
+
+  it('does not wrap plain mention-only text as Markdown', () => {
+    const html = render('Hi @[uid:7]', [{ uid: 7, username: 'Alice', gender: 0 }]);
+    expect(html).toContain('@Alice');
+    expect(html).not.toContain('<p>');
+  });
+
+  it('renders invite widget for autolinked invite URL and keeps explicit links as anchors', () => {
+    const html = render('join https://example.test/invite/abc today');
+    expect(html).toContain('data-kind="invite"');
+
+    const explicit = render('[join](https://example.test/invite/abc)');
+    expect(explicit).toContain('>join</a>');
+    expect(explicit).toContain('href="https://example.test/invite/abc"');
+  });
+});

--- a/wetty-chat-mobile/src/components/chat/messages/messageContent.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/messageContent.tsx
@@ -1,7 +1,17 @@
 import type { ReactNode } from 'react';
+import type { Token } from 'markdown-it';
 import type { MentionInfo } from '@/api/messages';
 import { MENTION_REGEX, MENTION_TEST, TRAILING_PUNCT, URL_REGEX } from '@/utils/chatTextMeasure';
 import { parseInviteCodeFromUrl } from '@/utils/inviteUrl';
+import { findCodeRegions } from '@/utils/markdown/codeRegions';
+import { hasEscapedPunctuation } from '@/utils/markdown/detect';
+import { markdownEngine } from '@/utils/markdown/engine';
+import { buildPlaceholder } from '@/utils/markdown/placeholder';
+import {
+  renderMarkdownTokens,
+  type MarkdownRenderOptions,
+} from '@/utils/markdown/react-renderer';
+import { tokensContainBlocks, tokensContainMarkup } from '@/utils/markdown/tokens';
 import { decodePermalink } from '@/utils/permalinkUrl';
 import styles from './ChatBubble.module.scss';
 import { InviteLinkInline } from './InviteLinkInline';
@@ -23,64 +33,107 @@ function parsePermalinkFromUrl(url: string): { chatId: string; messageId: string
   }
 }
 
-function renderMessageWithLinks(message: string): ReactNode[] {
-  const parts = message.split(URL_REGEX);
-  if (parts.length === 1) return [message];
-
-  return parts.map((part, index) => {
-    if (index % 2 === 1) {
-      const trimmed = part.replace(TRAILING_PUNCT, '');
-      const suffix = part.slice(trimmed.length);
-      const inviteCode = parseInviteCodeFromUrl(trimmed);
-      const permalink = !inviteCode ? parsePermalinkFromUrl(trimmed) : null;
-      return (
-        <span key={index}>
-          {inviteCode ? (
-            <InviteLinkInline code={inviteCode} url={trimmed} />
-          ) : permalink ? (
-            <PermalinkInline
-              targetChatId={permalink.chatId}
-              targetMessageId={permalink.messageId}
-              encoded={permalink.encoded}
-              url={trimmed}
-            />
-          ) : (
-            <a
-              href={trimmed}
-              className={styles.messageLink}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={(event) => event.stopPropagation()}
-            >
-              {trimmed}
-            </a>
-          )}
-          {suffix}
-        </span>
-      );
-    }
-
-    return part;
-  });
+function mentionClassName(
+  uid: number,
+  currentUserUid: number | null | undefined,
+  onMentionClick: ((uid: number) => void) | undefined,
+): string {
+  const isSelf = currentUserUid != null && uid === currentUserUid;
+  const clickable = onMentionClick != null;
+  return `${styles.mention}${isSelf ? ` ${styles.mentionSelf}` : ''}${clickable ? ` ${styles.mentionClickable}` : ''}`;
 }
 
-export function renderMessageContent(
+function buildMentionMap(mentions: MentionInfo[] | undefined): Map<number, string> {
+  const map = new Map<number, string>();
+  if (mentions) {
+    for (const mention of mentions) {
+      if (mention.username) map.set(mention.uid, mention.username);
+    }
+  }
+  return map;
+}
+
+function renderMentionNode(
+  uid: number,
+  username: string | undefined,
+  currentUserUid: number | null | undefined,
+  onMentionClick: ((uid: number) => void) | undefined,
+): ReactNode {
+  return (
+    <span
+      className={mentionClassName(uid, currentUserUid, onMentionClick)}
+      onClick={
+        onMentionClick
+          ? (event) => {
+              event.stopPropagation();
+              onMentionClick(uid);
+            }
+          : undefined
+      }
+    >
+      @{username ?? `User ${uid}`}
+    </span>
+  );
+}
+
+/**
+ * Renders a message body without any Markdown interpretation: splits out
+ * mentions (`@[uid:N]`) and bare URLs (external / invite / `/m/…` permalink)
+ * into their interactive widgets. This is the fallback used when the message
+ * carries no Markdown meaning at all.
+ */
+export function renderMessageContentLegacy(
   message: string,
   mentions: MentionInfo[] | undefined,
   currentUserUid: number | null | undefined,
   onMentionClick: ((uid: number) => void) | undefined,
 ): ReactNode[] {
+  const renderWithLinks = (text: string): ReactNode[] => {
+    const parts = text.split(URL_REGEX);
+    if (parts.length === 1) return [text];
+
+    return parts.map((part, index) => {
+      if (index % 2 === 1) {
+        const trimmed = part.replace(TRAILING_PUNCT, '');
+        const suffix = part.slice(trimmed.length);
+        const inviteCode = parseInviteCodeFromUrl(trimmed);
+        const permalink = !inviteCode ? parsePermalinkFromUrl(trimmed) : null;
+        return (
+          <span key={index}>
+            {inviteCode ? (
+              <InviteLinkInline code={inviteCode} url={trimmed} />
+            ) : permalink ? (
+              <PermalinkInline
+                targetChatId={permalink.chatId}
+                targetMessageId={permalink.messageId}
+                encoded={permalink.encoded}
+                url={trimmed}
+              />
+            ) : (
+              <a
+                href={trimmed}
+                className={styles.messageLink}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={(event) => event.stopPropagation()}
+              >
+                {trimmed}
+              </a>
+            )}
+            {suffix}
+          </span>
+        );
+      }
+
+      return part;
+    });
+  };
+
   if (!MENTION_TEST.test(message)) {
-    return renderMessageWithLinks(message);
+    return renderWithLinks(message);
   }
 
-  const mentionMap = new Map<number, string>();
-  if (mentions) {
-    for (const mention of mentions) {
-      if (mention.username) mentionMap.set(mention.uid, mention.username);
-    }
-  }
-
+  const mentionMap = buildMentionMap(mentions);
   const regex = new RegExp(MENTION_REGEX);
   const result: ReactNode[] = [];
   let lastIndex = 0;
@@ -88,19 +141,17 @@ export function renderMessageContent(
 
   while ((match = regex.exec(message)) !== null) {
     if (match.index > lastIndex) {
-      result.push(...renderMessageWithLinks(message.slice(lastIndex, match.index)));
+      result.push(...renderWithLinks(message.slice(lastIndex, match.index)));
     }
 
     const uid = parseInt(match[1], 10);
     const username = mentionMap.get(uid);
-    const isSelf = currentUserUid != null && uid === currentUserUid;
-    const clickable = onMentionClick != null;
     result.push(
       <span
         key={`mention-${uid}-${match.index}`}
-        className={`${styles.mention}${isSelf ? ` ${styles.mentionSelf}` : ''}${clickable ? ` ${styles.mentionClickable}` : ''}`}
+        className={mentionClassName(uid, currentUserUid, onMentionClick)}
         onClick={
-          clickable
+          onMentionClick
             ? (event) => {
                 event.stopPropagation();
                 onMentionClick(uid);
@@ -115,8 +166,123 @@ export function renderMessageContent(
   }
 
   if (lastIndex < message.length) {
-    result.push(...renderMessageWithLinks(message.slice(lastIndex)));
+    result.push(...renderWithLinks(message.slice(lastIndex)));
   }
 
   return result;
+}
+
+
+
+interface MentionWidget {
+  uid: number;
+  raw: string;
+}
+
+/**
+ * Swaps every mention outside code regions for a markdown-safe placeholder.
+ * The returned `body` is what gets parsed; `widgets` map placeholder slots back
+ * to the original mentions while rendering.
+ */
+function extractMentionWidgets(message: string): { body: string; widgets: MentionWidget[] } {
+  const regions = findCodeRegions(message);
+  const widgets: MentionWidget[] = [];
+  const parts: string[] = [];
+  const regex = new RegExp(MENTION_REGEX);
+  let cursor = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = regex.exec(message)) !== null) {
+    // Leave mentions inside code verbatim — carving them would lose the text.
+    if (regions.some((region) => match!.index >= region.start && match!.index < region.end)) {
+      continue;
+    }
+    parts.push(message.slice(cursor, match.index));
+    widgets.push({ uid: parseInt(match[1], 10), raw: match[0] });
+    parts.push(buildPlaceholder(widgets.length - 1));
+    cursor = match.index + match[0].length;
+  }
+  if (cursor < message.length) parts.push(message.slice(cursor));
+  return { body: parts.join(''), widgets };
+}
+
+/**
+ * Routes auto-detected invite / permalink URLs to their interactive widgets.
+ * Explicit `[label](url)` links keep their label as ordinary safe anchors.
+ */
+function renderAutolinkWidget(href: string, _label: ReactNode, token: Token): ReactNode | null | undefined {
+  if (token.info !== 'auto') return undefined;
+  const inviteCode = parseInviteCodeFromUrl(href);
+  const permalink = inviteCode ? null : parsePermalinkFromUrl(href);
+  if (inviteCode) return <InviteLinkInline code={inviteCode} url={href} />;
+  if (permalink) {
+    return (
+      <PermalinkInline
+        targetChatId={permalink.chatId}
+        targetMessageId={permalink.messageId}
+        encoded={permalink.encoded}
+        url={href}
+      />
+    );
+  }
+  return undefined;
+}
+
+export interface PreparedMessageContent {
+  /** True when the body was rendered with Markdown; `nodes` is then non-null. */
+  isMarkdown: boolean;
+  /** True when Markdown produced block structure (heading/list/quote/code/hr/multi-paragraph). */
+  hasBlocks: boolean;
+  /** The rendered body when Markdown, otherwise null (use the legacy renderer). */
+  nodes: ReactNode[] | null;
+}
+
+/**
+ * One-shot Markdown analysis and rendering for a text message — the token list
+ * from a single parse is shared between the decision and the render.
+ */
+export function prepareMessageContent(
+  message: string,
+  mentions: MentionInfo[] | undefined,
+  currentUserUid: number | null | undefined,
+  onMentionClick: ((uid: number) => void) | undefined,
+): PreparedMessageContent {
+  const extraction = extractMentionWidgets(message);
+  const tokens = markdownEngine.parse(extraction.body, {});
+  const isMarkdown = hasEscapedPunctuation(message) || tokensContainMarkup(tokens);
+
+  if (!isMarkdown) {
+    return { isMarkdown: false, hasBlocks: false, nodes: null };
+  }
+
+  const mentionMap = buildMentionMap(mentions);
+  const options: MarkdownRenderOptions = {
+    onPlaceholder: (index) => {
+      const widget = extraction.widgets[index];
+      if (!widget) return undefined;
+      return renderMentionNode(widget.uid, mentionMap.get(widget.uid), currentUserUid, onMentionClick);
+    },
+    renderLink: renderAutolinkWidget,
+  };
+
+  return {
+    isMarkdown: true,
+    hasBlocks: tokensContainBlocks(tokens),
+    nodes: renderMarkdownTokens(tokens, options),
+  };
+}
+
+/**
+ * Unified message-body renderer: runs Markdown rendering whenever the message
+ * carries Markdown meaning, otherwise keeps the legacy plain-text renderer.
+ */
+export function renderMessageContent(
+  message: string,
+  mentions: MentionInfo[] | undefined,
+  currentUserUid: number | null | undefined,
+  onMentionClick: ((uid: number) => void) | undefined,
+): ReactNode[] {
+  const prepared = prepareMessageContent(message, mentions, currentUserUid, onMentionClick);
+  if (prepared.isMarkdown && prepared.nodes) return prepared.nodes;
+  return renderMessageContentLegacy(message, mentions, currentUserUid, onMentionClick);
 }

--- a/wetty-chat-mobile/src/components/chat/messages/messageContent.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/messageContent.tsx
@@ -7,10 +7,7 @@ import { findCodeRegions } from '@/utils/markdown/codeRegions';
 import { hasEscapedPunctuation } from '@/utils/markdown/detect';
 import { markdownEngine } from '@/utils/markdown/engine';
 import { buildPlaceholder } from '@/utils/markdown/placeholder';
-import {
-  renderMarkdownTokens,
-  type MarkdownRenderOptions,
-} from '@/utils/markdown/react-renderer';
+import { renderMarkdownTokens, type MarkdownRenderOptions } from '@/utils/markdown/react-renderer';
 import { tokensContainBlocks, tokensContainMarkup } from '@/utils/markdown/tokens';
 import { decodePermalink } from '@/utils/permalinkUrl';
 import styles from './ChatBubble.module.scss';
@@ -171,8 +168,6 @@ export function renderMessageContentLegacy(
 
   return result;
 }
-
-
 
 interface MentionWidget {
   uid: number;

--- a/wetty-chat-mobile/src/components/chat/pins/PinBanner.tsx
+++ b/wetty-chat-mobile/src/components/chat/pins/PinBanner.tsx
@@ -9,6 +9,7 @@ import { pinScopeKey, selectPinsForScope } from '@/store/pinsSlice';
 import { selectEffectiveLocale } from '@/store/settingsSlice';
 import { deletePin, deleteThreadPin } from '@/api/pins';
 import { formatMessagePreview, getNotificationPreviewLabels } from '@/utils/messagePreview';
+import { MarkdownSummaryText } from '@/components/chat/previews/MarkdownSummaryText';
 import styles from './PinBanner.module.scss';
 
 interface PinBannerProps {
@@ -98,7 +99,8 @@ export function PinBanner({
   if (!activePin) return null;
 
   const msg = activePin.message;
-  const previewText = formatMessagePreview(msg, getNotificationPreviewLabels(locale)) || t`Message`;
+  const previewText = formatMessagePreview(msg, getNotificationPreviewLabels(locale));
+  const preview = previewText ? <MarkdownSummaryText text={previewText} /> : t`Message`;
 
   return (
     <div className={styles.banner}>
@@ -114,7 +116,7 @@ export function PinBanner({
           <span className={styles.senderName} style={{ opacity: 0.85 }}>
             {msg.sender.name ?? `User ${msg.sender.uid}`}
           </span>
-          <span className={styles.messageText}>{previewText}</span>
+          <span className={styles.messageText}>{preview}</span>
         </div>
       </div>
 

--- a/wetty-chat-mobile/src/components/chat/pins/PinListModal.tsx
+++ b/wetty-chat-mobile/src/components/chat/pins/PinListModal.tsx
@@ -10,6 +10,7 @@ import { selectEffectiveLocale } from '@/store/settingsSlice';
 import type { PinResponse } from '@/api/pins';
 import { deletePin, deleteThreadPin } from '@/api/pins';
 import { formatMessagePreview, getNotificationPreviewLabels } from '@/utils/messagePreview';
+import { MarkdownSummaryText } from '@/components/chat/previews/MarkdownSummaryText';
 import styles from './PinListModal.module.scss';
 import { useIsDesktop } from '@/hooks/platformHooks';
 
@@ -97,7 +98,8 @@ export function PinListModal({
           <IonList className={styles.list}>
             {pins.map((pin) => {
               const msg = pin.message;
-              const previewText = formatMessagePreview(msg, getNotificationPreviewLabels(locale)) || t`Message`;
+              const previewText = formatMessagePreview(msg, getNotificationPreviewLabels(locale));
+              const preview = previewText ? <MarkdownSummaryText text={previewText} /> : t`Message`;
               const senderName = msg.sender.name ?? `User ${msg.sender.uid}`;
               return (
                 <IonItem
@@ -115,7 +117,7 @@ export function PinListModal({
                     )}
                     <div className={styles.pinBody}>
                       <span className={styles.pinSender}>{senderName}</span>
-                      <span className={styles.pinMessage}>{previewText}</span>
+                      <span className={styles.pinMessage}>{preview}</span>
                     </div>
                     <div className={styles.actions}>
                       {!threadRootId && msg.threadInfo && (

--- a/wetty-chat-mobile/src/components/chat/previews/MarkdownSummaryText.dom.test.tsx
+++ b/wetty-chat-mobile/src/components/chat/previews/MarkdownSummaryText.dom.test.tsx
@@ -1,0 +1,103 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { MarkdownSummaryText } from './MarkdownSummaryText';
+
+const featureMocks = vi.hoisted(() => ({
+  isFeatureEnabled: vi.fn<(name: string) => boolean>(),
+}));
+
+vi.mock('@/features', () => ({
+  isFeatureEnabled: featureMocks.isFeatureEnabled,
+}));
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(text: string, maxLength?: number) {
+  act(() => {
+    root.render(<MarkdownSummaryText text={text} maxLength={maxLength} />);
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  featureMocks.isFeatureEnabled.mockReturnValue(true);
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+describe('MarkdownSummaryText', () => {
+  it('renders inline Markdown (bold/italic/strikethrough/code) without raw syntax', () => {
+    render('**粗**、*斜*、~~删~~、`code`');
+
+    expect(container.querySelector('strong')?.textContent).toBe('粗');
+    expect(container.querySelector('em')?.textContent).toBe('斜');
+    expect(container.querySelector('s')?.textContent).toBe('删');
+    expect(container.querySelector('code')?.textContent).toBe('code');
+    expect(container.textContent).not.toContain('**');
+    expect(container.textContent).not.toContain('~~');
+    expect(container.textContent).toBe('粗、斜、删、code');
+  });
+
+  it('flattens block Markdown into a single inline line (no block elements, no <br>)', () => {
+    render('# 标题\n\n- 项一\n- 项二\n\n1. 甲\n2. 乙');
+
+    for (const tag of ['p', 'h1', 'h2', 'ul', 'ol', 'li', 'pre', 'blockquote', 'hr', 'br']) {
+      expect(container.querySelector(tag)).toBeNull();
+    }
+    // Heading is out of the subset and stays literal; lists keep their prefixes.
+    expect(container.querySelector('strong')).toBeNull();
+    expect(container.textContent).toContain('# 标题');
+    expect(container.textContent).toContain('项一');
+    expect(container.textContent).toContain('• 项二');
+    expect(container.textContent).toContain('1. 甲');
+    expect(container.textContent).toContain('2. 乙');
+  });
+
+  it('renders autolinks and markdown links as inline anchors', () => {
+    render('去 [链接](https://example.com) 看 https://auto.example/a');
+
+    const anchors = Array.from(container.querySelectorAll('a'));
+    expect(anchors.map((a) => a.getAttribute('href'))).toEqual(['https://example.com', 'https://auto.example/a']);
+    expect(container.textContent).not.toContain('[链接]');
+  });
+
+  it('renders Markdown next to a literal attachment label prefix', () => {
+    render('[图片] **新的设计** 已上传');
+
+    expect(container.textContent).toContain('[图片]');
+    expect(container.querySelector('strong')?.textContent).toBe('新的设计');
+    expect(container.textContent).not.toContain('**');
+  });
+
+  it('returns plain text unchanged when the feature gate is off', () => {
+    featureMocks.isFeatureEnabled.mockReturnValue(false);
+    render('别 **加粗** 我');
+
+    expect(container.textContent).toBe('别 **加粗** 我');
+    expect(container.querySelector('strong')).toBeNull();
+  });
+
+  it('truncates only the plain-text fallback when maxLength is given', () => {
+    const longText = 'a'.repeat(60);
+    render(longText, 8);
+
+    expect(container.textContent).toMatch(/^a{7,8}…$/);
+  });
+
+  it('renders nothing for an empty string', () => {
+    render('');
+
+    expect(container.textContent).toBe('');
+  });
+});

--- a/wetty-chat-mobile/src/components/chat/previews/MarkdownSummaryText.tsx
+++ b/wetty-chat-mobile/src/components/chat/previews/MarkdownSummaryText.tsx
@@ -1,0 +1,31 @@
+import { Fragment } from 'react';
+import { isFeatureEnabled } from '@/features';
+import { messageHasMarkdown } from '@/utils/markdown/detect';
+import { renderMarkdownPreview } from '@/utils/markdown/preview';
+import { truncatePreview } from '@/utils/messagePreview';
+
+interface MarkdownSummaryTextProps {
+  /** Formatted preview text (`@username` mentions, literal `[图片]` labels). */
+  text: string;
+  /**
+   * Legacy plain-text truncation cap. On the Markdown path it is never applied
+   * — long text is clipped by the parent's single-line CSS instead, so `**`
+   * markers are never sliced mid-syntax.
+   */
+  maxLength?: number;
+}
+
+/**
+ * Single-line summary for chat-list / thread / pin / reply / search previews.
+ * Markdown text renders inline-flattened; otherwise the exact legacy plain
+ * string (optionally truncated) is returned.
+ */
+export function MarkdownSummaryText({ text, maxLength }: MarkdownSummaryTextProps) {
+  if (!text) return null;
+
+  if (isFeatureEnabled('messageMarkdown') && messageHasMarkdown(text)) {
+    return <Fragment>{renderMarkdownPreview(text)}</Fragment>;
+  }
+
+  return maxLength === undefined ? text : truncatePreview(text, maxLength);
+}

--- a/wetty-chat-mobile/src/components/chat/search/ChatMessageSearchPanel.tsx
+++ b/wetty-chat-mobile/src/components/chat/search/ChatMessageSearchPanel.tsx
@@ -17,7 +17,8 @@ import { useSelector } from 'react-redux';
 import { type MessageResponse, searchMessages } from '@/api/messages';
 import { UserAvatar } from '@/components/UserAvatar';
 import { selectEffectiveLocale } from '@/store/settingsSlice';
-import { formatMessagePreview, getNotificationPreviewLabels, truncatePreview } from '@/utils/messagePreview';
+import { formatMessagePreview, getNotificationPreviewLabels } from '@/utils/messagePreview';
+import { MarkdownSummaryText } from '@/components/chat/previews/MarkdownSummaryText';
 import { isMessageSearchQueryReady } from '@/utils/messageSearch';
 import styles from './ChatMessageSearchPanel.module.scss';
 
@@ -57,10 +58,10 @@ function formatResultTimestamp(isoString: string, locale: string): string {
 
 function MessageSearchResultRow({ message, locale, onSelect }: MessageSearchResultRowProps) {
   const senderName = message.sender.name ?? `User ${message.sender.uid}`;
-  const previewText = useMemo(() => {
-    const formatted = formatMessagePreview(message, getNotificationPreviewLabels(locale));
-    return truncatePreview(formatted || t`Message`);
-  }, [locale, message]);
+  const previewText = useMemo(
+    () => formatMessagePreview(message, getNotificationPreviewLabels(locale)) || t`Message`,
+    [locale, message],
+  );
   const timestamp = useMemo(() => formatResultTimestamp(message.createdAt, locale), [locale, message.createdAt]);
 
   return (
@@ -73,7 +74,9 @@ function MessageSearchResultRow({ message, locale, onSelect }: MessageSearchResu
           <span className={styles.senderName}>{senderName}</span>
           {timestamp ? <IonNote className={styles.timestamp}>{timestamp}</IonNote> : null}
         </div>
-        <p className={styles.previewText}>{previewText}</p>
+        <p className={styles.previewText}>
+          <MarkdownSummaryText text={previewText} />
+        </p>
         {message.replyRootId != null && (
           <p className={styles.threadLabel}>
             <IonIcon icon={chatbubbles} className={styles.threadIcon} /> {t`In thread`}

--- a/wetty-chat-mobile/src/features.test.ts
+++ b/wetty-chat-mobile/src/features.test.ts
@@ -20,4 +20,12 @@ describe('feature gates', () => {
     expect(FEATURES.savedMessages.enabled).toBe(true);
     expect(isFeatureEnabled('savedMessages')).toBe(true);
   });
+
+  it('registers messageMarkdown default-enabled so Markdown rendering and the format toolbar are active', async () => {
+    vi.stubGlobal('__FEATURE_GATES_ENABLED__', false);
+    const { FEATURES, isFeatureEnabled } = await import('./features');
+
+    expect(FEATURES.messageMarkdown.enabled).toBe(true);
+    expect(isFeatureEnabled('messageMarkdown')).toBe(true);
+  });
 });

--- a/wetty-chat-mobile/src/features.ts
+++ b/wetty-chat-mobile/src/features.ts
@@ -63,6 +63,10 @@ export const FEATURES = {
     enabled: true,
     description: 'Blocklist (Chahua-side 「拉黑」) affecting DM and friend relationships only.',
   },
+  messageMarkdown: {
+    enabled: true,
+    description: 'Renders chat messages (and chat-list previews) as Markdown and shows a formatting toolbar when text is selected in the composer.',
+  },
 } as const;
 
 export type Feature = keyof typeof FEATURES;

--- a/wetty-chat-mobile/src/features.ts
+++ b/wetty-chat-mobile/src/features.ts
@@ -65,7 +65,8 @@ export const FEATURES = {
   },
   messageMarkdown: {
     enabled: true,
-    description: 'Renders chat messages (and chat-list previews) as Markdown and shows a formatting toolbar when text is selected in the composer.',
+    description:
+      'Renders chat messages (and chat-list previews) as Markdown and shows a formatting toolbar when text is selected in the composer.',
   },
 } as const;
 

--- a/wetty-chat-mobile/src/utils/markdown/codeRegions.ts
+++ b/wetty-chat-mobile/src/utils/markdown/codeRegions.ts
@@ -1,0 +1,79 @@
+/** A `[start, end)` region of the source. */
+export interface TextRegion {
+  start: number;
+  end: number;
+}
+
+/**
+ * Finds the source regions Markdown treats as code (fenced blocks and same-line
+ * inline code spans). Mentions inside those regions must NOT be carved into
+ * placeholders: code renders verbatim, so carving would erase the mention text.
+ */
+export function findCodeRegions(source: string): TextRegion[] {
+  const regions: TextRegion[] = [];
+  const length = source.length;
+
+  const startsLine = (pos: number): boolean => {
+    if (pos === 0) return true;
+    const lineStart = source.lastIndexOf('\n', pos - 1) + 1;
+    return pos - lineStart <= 3 && source.slice(lineStart, pos).trim() === '';
+  };
+
+  let pos = 0;
+  while (pos < length) {
+    const ch = source[pos];
+    if (ch !== '`' && ch !== '~') {
+      pos += 1;
+      continue;
+    }
+    let run = 1;
+    while (pos + run < length && source[pos + run] === ch) run += 1;
+
+    if (run >= 3 && startsLine(pos)) {
+      // Fenced code block — scan for a closing fence of the same char.
+      let scan = source.indexOf('\n', pos + run);
+      let end = -1;
+      while (scan !== -1) {
+        const lineStart = scan + 1;
+        let k = lineStart;
+        while (k < length && source[k] === ' ') k += 1;
+        if (k - lineStart <= 3 && source[k] === ch) {
+          let closeRun = 1;
+          while (k + closeRun < length && source[k + closeRun] === ch) closeRun += 1;
+          if (closeRun >= run) {
+            end = k + closeRun;
+            break;
+          }
+        }
+        scan = source.indexOf('\n', scan + 1);
+      }
+      regions.push({ start: pos, end: end === -1 ? length : end });
+      pos = end === -1 ? length : end;
+      continue;
+    }
+
+    if (ch === '`') {
+      // Inline code span — the same tick run must close on the same line.
+      const lineEnd = source.indexOf('\n', pos + run);
+      const lineLimit = lineEnd === -1 ? length : lineEnd;
+      let close = -1;
+      for (let k = pos + run; k + run <= lineLimit; k += 1) {
+        if (source[k] === '`') {
+          let inner = 1;
+          while (k + inner < length && source[k + inner] === '`') inner += 1;
+          if (inner === run) {
+            close = k;
+            break;
+          }
+        }
+      }
+      if (close !== -1) {
+        regions.push({ start: pos, end: close + run });
+        pos = close + run;
+        continue;
+      }
+    }
+    pos += run;
+  }
+  return regions;
+}

--- a/wetty-chat-mobile/src/utils/markdown/detect.test.ts
+++ b/wetty-chat-mobile/src/utils/markdown/detect.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import { messageHasMarkdown } from './detect';
+
+describe('messageHasMarkdown', () => {
+  it('rejects empty and plain text', () => {
+    expect(messageHasMarkdown('')).toBe(false);
+    expect(messageHasMarkdown('hello world')).toBe(false);
+    expect(messageHasMarkdown('5 * 3 = 15')).toBe(false);
+    expect(messageHasMarkdown('a ~2~ b')).toBe(false);
+    expect(messageHasMarkdown('你好世界')).toBe(false);
+  });
+
+  it('detects inline emphasis, code, underline and strikethrough', () => {
+    expect(messageHasMarkdown('**bold** text')).toBe(true);
+    expect(messageHasMarkdown('*italic*')).toBe(true);
+    expect(messageHasMarkdown('a ~~strike~~ b')).toBe(true);
+    expect(messageHasMarkdown('a __underline__ b')).toBe(true);
+    expect(messageHasMarkdown('`inline code`')).toBe(true);
+  });
+
+  it('detects explicit links and linkified bare URLs', () => {
+    expect(messageHasMarkdown('[label](https://a.b)')).toBe(true);
+    expect(messageHasMarkdown('a https://auto.example/path b')).toBe(true);
+  });
+
+  it('detects the supported block constructs', () => {
+    expect(messageHasMarkdown('> quote')).toBe(true);
+    expect(messageHasMarkdown('- item')).toBe(true);
+    expect(messageHasMarkdown('1. item')).toBe(true);
+    expect(messageHasMarkdown('```\ncode\n```')).toBe(true);
+  });
+
+  it('keeps removed syntax literal (single underscore, headings, hr, image)', () => {
+    expect(messageHasMarkdown('_underscore em_')).toBe(false);
+    expect(messageHasMarkdown('# heading')).toBe(false);
+    expect(messageHasMarkdown('---')).toBe(false);
+    // A relative target avoids linkify, so the image macro stays pure text.
+    expect(messageHasMarkdown('![alt](diagram.png)')).toBe(false);
+    expect(messageHasMarkdown('    indented code')).toBe(false);
+  });
+
+  it('treats several plain lines as one paragraph', () => {
+    expect(messageHasMarkdown('first line\nsecond line')).toBe(false);
+  });
+
+  it('counts escaped punctuation as markdown intent', () => {
+    expect(messageHasMarkdown('\\*not emphasis\\*')).toBe(true);
+    expect(messageHasMarkdown('literal \\[bracket\\]')).toBe(true);
+  });
+
+  it('does not flag backslashes in paths or regexes', () => {
+    expect(messageHasMarkdown('C:\\path\\to\\file')).toBe(false);
+    expect(messageHasMarkdown('\\d+ matches digits')).toBe(false);
+    expect(messageHasMarkdown('backslash at end\\')).toBe(false);
+  });
+
+  it('ignores mentions and bare words', () => {
+    expect(messageHasMarkdown('@[uid:1] hello')).toBe(false);
+    expect(messageHasMarkdown('mention @alice here')).toBe(false);
+  });
+});

--- a/wetty-chat-mobile/src/utils/markdown/detect.ts
+++ b/wetty-chat-mobile/src/utils/markdown/detect.ts
@@ -1,0 +1,29 @@
+import type { Token } from 'markdown-it';
+import { markdownEngine } from './engine';
+import { tokensContainMarkup } from './tokens';
+
+// CommonMark "ASCII punctuation": the only characters a backslash may escape.
+const ESCAPABLE_ASCII_PUNCT = `!"#$%&'()*+,-./:;<=>?@[\\]^_\`{|}~`;
+
+export function hasEscapedPunctuation(text: string): boolean {
+  for (let i = 0; i < text.length - 1; i++) {
+    if (text[i] !== '\\') continue;
+    if (ESCAPABLE_ASCII_PUNCT.indexOf(text[i + 1]) !== -1) return true;
+  }
+  return false;
+}
+
+/**
+ * Decides whether a message needs the Markdown renderer, reusing a token list
+ * the caller has already parsed so one parse feeds both this check and the
+ * render. Escaped punctuation (`\*literal\*`) produces no markup token, yet the
+ * backslash must still be stripped, so it is detected from the raw text too.
+ */
+export function hasMarkdownText(text: string, tokens: readonly Token[]): boolean {
+  return hasEscapedPunctuation(text) || tokensContainMarkup(tokens);
+}
+
+export function messageHasMarkdown(text: string): boolean {
+  if (!text) return false;
+  return hasMarkdownText(text, markdownEngine.parse(text, {}));
+}

--- a/wetty-chat-mobile/src/utils/markdown/engine.test.ts
+++ b/wetty-chat-mobile/src/utils/markdown/engine.test.ts
@@ -46,9 +46,7 @@ describe('`*` is not a list marker', () => {
   });
 
   it('still allows emphasis right after a literal star line', () => {
-    expect(markdownEngine.render('* item\n**bold**', {}).trim()).toBe(
-      '<p>* item<br>\n<strong>bold</strong></p>',
-    );
+    expect(markdownEngine.render('* item\n**bold**', {}).trim()).toBe('<p>* item<br>\n<strong>bold</strong></p>');
   });
 
   it('keeps dash and ordered lists working', () => {
@@ -68,9 +66,7 @@ describe('single-asterisk italic space-adaptation', () => {
   });
 
   it('forgives only one stray space, not symmetric spacing', () => {
-    expect(markdownEngine.render('*italic words here *', {}).trim()).toContain(
-      '<em>italic words here</em>',
-    );
+    expect(markdownEngine.render('*italic words here *', {}).trim()).toContain('<em>italic words here</em>');
     expect(markdownEngine.render('* x *', {}).trim()).toBe('<p>* x *</p>');
   });
 

--- a/wetty-chat-mobile/src/utils/markdown/engine.test.ts
+++ b/wetty-chat-mobile/src/utils/markdown/engine.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+
+import { createMarkdownEngine, markdownEngine } from './engine';
+
+describe('markdown engine configuration', () => {
+  it('keeps raw HTML inert by default (html:false)', () => {
+    expect(markdownEngine.render('<script>alert(1)</script>', {})).toBe(
+      '<p>&lt;script&gt;alert(1)&lt;/script&gt;</p>\n',
+    );
+  });
+
+  it('supports strikethrough out of the box (default preset)', () => {
+    expect(markdownEngine.render('~~gone~~', {}).trim()).toBe('<p><s>gone</s></p>');
+  });
+
+  it('does not treat single tildes as markup', () => {
+    expect(markdownEngine.render('a ~2~ b', {}).trim()).toBe('<p>a ~2~ b</p>');
+  });
+
+  it('breaks single newlines into hard line breaks (breaks:true)', () => {
+    expect(markdownEngine.render('a\nb', {}).trim()).toBe('<p>a<br>\nb</p>');
+  });
+
+  it('never turns javascript: URLs into links', () => {
+    expect(markdownEngine.render('[x](javascript:alert(1))', {}).trim()).toBe('<p>[x](javascript:alert(1))</p>');
+  });
+
+  it('linkifies bare URLs with trailing markup normalized', () => {
+    expect(markdownEngine.render('see http://example.com/x?y=1 now', {}).trim()).toBe(
+      '<p>see <a href="http://example.com/x?y=1">http://example.com/x?y=1</a> now</p>',
+    );
+  });
+
+  it('keeps raw HTML inert even when html is requested (out of subset)', () => {
+    // HTML rules are disabled by the subset regardless of the `html` option,
+    // so an instance created with html:true still cannot execute tags.
+    const md = createMarkdownEngine({ html: true });
+    expect(md.render('<b>x</b>', {}).trim()).toBe('<p>&lt;b&gt;x&lt;/b&gt;</p>');
+  });
+});
+
+describe('`*` is not a list marker', () => {
+  it('keeps star-bullet lines as text instead of a list', () => {
+    expect(markdownEngine.render('* item', {}).trim()).toBe('<p>* item</p>');
+    expect(markdownEngine.render('* item\n* two', {}).trim()).toBe('<p>* item<br>\n* two</p>');
+  });
+
+  it('still allows emphasis right after a literal star line', () => {
+    expect(markdownEngine.render('* item\n**bold**', {}).trim()).toBe(
+      '<p>* item<br>\n<strong>bold</strong></p>',
+    );
+  });
+
+  it('keeps dash and ordered lists working', () => {
+    const dash = markdownEngine.render('- a\n- b', {}).trim();
+    expect(dash.startsWith('<ul>')).toBe(true);
+    expect(dash).toContain('<li>a</li>');
+    expect(dash).toContain('<li>b</li>');
+  });
+});
+
+describe('single-asterisk italic space-adaptation', () => {
+  it('forgives a single stray space inside a mention star pair', () => {
+    // `*@devuser2 *` was the failing manual-test input: the space on the inner
+    // side of the closing `*` kept the pair literal under CommonMark.
+    expect(markdownEngine.render('*@devuser2 *', {}).trim()).toContain('<em>@devuser2</em>');
+    expect(markdownEngine.render('* @devuser2*', {}).trim()).toContain('<em>@devuser2</em>');
+  });
+
+  it('forgives only one stray space, not symmetric spacing', () => {
+    expect(markdownEngine.render('*italic words here *', {}).trim()).toContain(
+      '<em>italic words here</em>',
+    );
+    expect(markdownEngine.render('* x *', {}).trim()).toBe('<p>* x *</p>');
+  });
+
+  it('keeps arithmetic-like symmetric `5 * 3 * 4` literal', () => {
+    expect(markdownEngine.render('5 * 3 * 4', {}).trim()).toBe('<p>5 * 3 * 4</p>');
+    expect(markdownEngine.render('a *2 * b', {}).trim()).toBe('<p>a *2 * b</p>');
+  });
+
+  it('never touches stars inside code spans', () => {
+    expect(markdownEngine.render('`*a *`', {}).trim()).toBe('<p><code>*a *</code></p>');
+  });
+});

--- a/wetty-chat-mobile/src/utils/markdown/engine.ts
+++ b/wetty-chat-mobile/src/utils/markdown/engine.ts
@@ -1,0 +1,42 @@
+import MarkdownIt from 'markdown-it';
+import type { MarkdownIt as MarkdownItInstance, Token } from 'markdown-it';
+
+import { applyMarkdownSubset } from './rules';
+import { normalizeMarkdownBeforeParse } from './normalize';
+
+/**
+ * markdown-it tuned for chat messages: raw HTML renders as text, bare URLs and
+ * single newlines become links / `<br>`, and only the supported subset in
+ * rules.ts ever produces tokens. Every parse first runs
+ * {@link normalizeMarkdownBeforeParse} so out-of-subset input and marker pairs
+ * with stray inner spaces render predictably.
+ */
+export interface MarkdownEngineOptions {
+  html?: boolean;
+  breaks?: boolean;
+  linkify?: boolean;
+}
+
+interface ParseOverridable {
+  parse: (src: string, env?: Record<string, unknown>) => Token[];
+}
+
+export function createMarkdownEngine(options: MarkdownEngineOptions = {}): MarkdownItInstance {
+  const md = new MarkdownIt({
+    html: options.html ?? false,
+    linkify: options.linkify ?? true,
+    breaks: options.breaks ?? true,
+    typographer: false,
+  });
+
+  applyMarkdownSubset(md);
+
+  const self = md as unknown as ParseOverridable;
+  const nativeParse = self.parse.bind(self);
+  self.parse = (src: string, env?: Record<string, unknown>): Token[] =>
+    nativeParse(normalizeMarkdownBeforeParse(src), env ?? {});
+
+  return md;
+}
+
+export const markdownEngine = createMarkdownEngine();

--- a/wetty-chat-mobile/src/utils/markdown/normalize.ts
+++ b/wetty-chat-mobile/src/utils/markdown/normalize.ts
@@ -1,0 +1,241 @@
+/**
+ * Whitespace reflow before Markdown parsing.
+ *
+ * CommonMark makes `** bold **` render literally, so formatting a selection
+ * that already included spaces (`  hello  `) would leave the result unstyled.
+ * This module moves those redundant spaces OUTSIDE the paired markers so the
+ * content renders while ordinary text stays untouched:
+ *
+ *     `a** b **c`       →  `a **b** c`
+ *     `** @[uid:1] **`  →  ` **@[uid:1]** `
+ *
+ * Two-character runs (`**`/`~~`/`__`) forgive spaces on either inner side;
+ * single-`*` italic forgives one side only so arithmetic-like `5 * 3 * 4` is
+ * never altered. Code spans, fences, escaped characters and multi-line
+ * content are skipped.
+ */
+
+/** Returns a mask of character indexes inside code spans/fences or escapes. */
+function maskCodeRegions(src: string): boolean[] {
+  const n = src.length;
+  const masked = new Array<boolean>(n).fill(false);
+  const atLineStart = (idx: number): boolean => idx === 0 || src[idx - 1] === '\n';
+
+  const maskRange = (from: number, to: number): void => {
+    for (let x = from; x < to && x < n; x++) masked[x] = true;
+  };
+
+  let i = 0;
+  while (i < n) {
+    const ch = src[i];
+
+    if (ch === '\\' && i + 1 < n) {
+      masked[i] = true;
+      masked[i + 1] = true;
+      i += 2;
+      continue;
+    }
+
+    // Fenced code block: a line with ≤3 leading spaces whose first non-space
+    // chars are a fence run (``` or ~~~, ≥3). Mask through the closing fence;
+    // an unclosed fence masks to EOF.
+    if (atLineStart(i) && (ch === ' ' || ch === '\t' || ch === '`' || ch === '~')) {
+      let probe = i;
+      let lead = 0;
+      while (probe < n && (src[probe] === ' ' || src[probe] === '\t') && lead < 3) {
+        probe++;
+        lead++;
+      }
+      if (probe < n && (src[probe] === '`' || src[probe] === '~')) {
+        const fenceChar = src[probe];
+        let run = probe;
+        while (run < n && src[run] === fenceChar) run++;
+        const openLen = run - probe;
+        if (openLen >= 3) {
+          let lineEnd = run;
+          while (lineEnd < n && src[lineEnd] !== '\n') lineEnd++;
+          maskRange(i, lineEnd);
+          // Closing fence must live on a later line than the opening one.
+          let cursor = lineEnd < n ? lineEnd + 1 : n;
+          while (cursor < n) {
+            let e = cursor;
+            while (e < n && src[e] !== '\n') e++;
+            let p2 = cursor;
+            let l2 = 0;
+            while (p2 < e && (src[p2] === ' ' || src[p2] === '\t') && l2 < 3) {
+              p2++;
+              l2++;
+            }
+            let isClosing = false;
+            if (p2 < e && src[p2] === fenceChar) {
+              let r2 = p2;
+              while (r2 < e && src[r2] === fenceChar) r2++;
+              if (r2 - p2 >= openLen) {
+                let t2 = r2;
+                while (t2 < e && (src[t2] === ' ' || src[t2] === '\t')) t2++;
+                isClosing = t2 === e; // only trailing spaces may follow the fence
+              }
+            }
+            maskRange(cursor, e);
+            cursor = e < n ? e + 1 : n;
+            if (isClosing) break;
+          }
+          i = cursor;
+          continue;
+        }
+      }
+    }
+
+    // Inline code span: a run of L backticks closes at the next run of exactly
+    // L backticks on the same line; unclosed spans stay unmasked.
+    if (ch === '`') {
+      let run = i;
+      while (run < n && src[run] === '`') run++;
+      const L = run - i;
+      let j = run;
+      let closeAt = -1;
+      while (j < n) {
+        if (src[j] === '`') {
+          let rr = j;
+          while (rr < n && src[rr] === '`') rr++;
+          if (rr - j === L) {
+            closeAt = j;
+            break;
+          }
+          j = rr;
+        } else {
+          j++;
+        }
+      }
+      if (closeAt === -1) {
+        i = run;
+        continue;
+      }
+      maskRange(i, closeAt + L);
+      i = closeAt + L;
+      continue;
+    }
+
+    i++;
+  }
+  return masked;
+}
+
+interface MarkerRun {
+  start: number;
+  ch: string;
+}
+
+type ReflowMode = 'two' | 'one';
+
+function collectPairs(src: string, masked: boolean[], mode: ReflowMode): Array<[number, number]> {
+  const n = src.length;
+  const runs: MarkerRun[] = [];
+  let i = 0;
+  while (i < n) {
+    if (masked[i] || (src[i] !== '*' && src[i] !== '~' && src[i] !== '_')) {
+      i++;
+      continue;
+    }
+    const ch = src[i];
+    let j = i;
+    while (j < n && src[j] === ch) j++;
+    const len = j - i;
+    // `two`: exact `**`/`~~`/`__` runs. `one`: isolated single `*` only.
+    if (len === (mode === 'two' ? 2 : 1) && (mode === 'one' ? ch === '*' : true)) {
+      runs.push({ start: i, ch });
+    }
+    i = j;
+  }
+
+  const pairs: Array<[number, number]> = [];
+  for (let t = 0; t + 1 < runs.length; t += 2) {
+    pairs.push([runs[t].start, runs[t + 1].start]);
+  }
+  return pairs;
+}
+
+/**
+ * Moves redundant spaces directly inside a paired marker to its outside.
+ * `two` (`**`/`~~`/`__`) forgives spaces on either inner side; `one` (`*…*`)
+ * forgives a stray space on one side only, so `5 * 3 * 4` keeps literal stars.
+ */
+function reflowPairedSpaces(src: string, mode: ReflowMode): string {
+  if (!src) return src;
+  const masked = maskCodeRegions(src);
+  const pairs = collectPairs(src, masked, mode);
+  const markerLen = mode === 'two' ? 2 : 1;
+
+  let out = src;
+  for (let p = pairs.length - 1; p >= 0; p--) {
+    const [openStart, closeStart] = pairs[p];
+    if (closeStart <= openStart + markerLen) continue; // adjacent markers, no content
+
+    const mid = out.slice(openStart + markerLen, closeStart);
+    if (mid.includes('\n')) continue; // never reflow across line breaks
+
+    let lead = 0;
+    while (lead < mid.length && (mid[lead] === ' ' || mid[lead] === '\t')) lead++;
+    let trail = 0;
+    while (trail < mid.length - lead && (mid[mid.length - 1 - trail] === ' ' || mid[mid.length - 1 - trail] === '\t')) {
+      trail++;
+    }
+    const inner = mid.slice(lead, mid.length - trail);
+    if (inner.length <= 0) continue; // whitespace-only pair
+    if (lead === 0 && trail === 0) continue; // nothing to move
+    if (mode === 'one' && lead > 0 && trail > 0) continue; // `5 * 3 * 4` stays literal
+
+    // Digits adjacent to the markers or numeric-only content stay literal too.
+    const prevChar = openStart > 0 ? out[openStart - 1] : '';
+    const nextChar = closeStart + markerLen < out.length ? out[closeStart + markerLen] : '';
+    if (/[0-9]/.test(prevChar) || /[0-9]/.test(nextChar)) continue;
+    if (mode === 'one' && /^[0-9][0-9.,%]*$/.test(inner)) continue;
+    if (mode === 'two' && out[openStart] === '_' && (/[A-Za-z0-9]/.test(prevChar) || /[A-Za-z0-9]/.test(nextChar))) {
+      continue;
+    }
+
+    const marker = mode === 'two' ? out[openStart] + out[openStart] : '*';
+    const leadWs = mid.slice(0, lead);
+    const trailWs = mid.slice(mid.length - trail);
+
+    out = out.slice(0, openStart) + leadWs + marker + inner + marker + trailWs + out.slice(closeStart + markerLen);
+  }
+  return out;
+}
+
+/** Reflows `**`/`~~`/`__` first, then single-`*` italic on the result. */
+export function normalizeMarkdownWhitespace(src: string): string {
+  if (!src) return src;
+  return reflowPairedSpaces(reflowPairedSpaces(src, 'two'), 'one');
+}
+
+/**
+ * Guards out-of-subset image macros so they render verbatim. Disabling the
+ * `image` rule alone is not enough: `![alt](url)` would still parse as `!`
+ * followed by a normal `[alt](url)` link. Backslash-escaping the `[` keeps the
+ * whole macro literal while other Markdown beside it parses normally.
+ */
+function escapeImageMacros(src: string, masked: boolean[]): string {
+  const parts: string[] = [];
+  let i = 0;
+  let last = 0;
+  while (i < src.length) {
+    if (!masked[i] && i + 1 < src.length && src[i] === '!' && src[i + 1] === '[' && !masked[i + 1]) {
+      parts.push(src.slice(last, i + 1)); // up to and including the `!`
+      parts.push('\\');
+      last = i + 1; // the `[` goes into the next segment
+      i += 2;
+    } else {
+      i++;
+    }
+  }
+  if (last < src.length) parts.push(src.slice(last));
+  return parts.join('');
+}
+
+/** Full pre-parse normalization applied by the engine on every parse. */
+export function normalizeMarkdownBeforeParse(src: string): string {
+  if (!src) return src;
+  const masked = maskCodeRegions(src);
+  return normalizeMarkdownWhitespace(escapeImageMacros(src, masked));
+}

--- a/wetty-chat-mobile/src/utils/markdown/placeholder.ts
+++ b/wetty-chat-mobile/src/utils/markdown/placeholder.ts
@@ -1,0 +1,81 @@
+/**
+ * Placeholder protocol that lets interactive widgets (`@[uid:N]`, invite
+ * links, `/m/…` permalinks) survive a Markdown parse. The caller swaps each
+ * widget for an invisible `\uFFF0<index>\uFFF1` sequence before parsing and
+ * restores it while rendering text tokens. Widgets are carved only outside
+ * code spans/fences, since code content renders verbatim and never reaches the
+ * restore hook.
+ */
+const OPEN = 0xfff0;
+const CLOSE = 0xfff1;
+
+export const PLACEHOLDER_OPEN = String.fromCharCode(OPEN);
+export const PLACEHOLDER_CLOSE = String.fromCharCode(CLOSE);
+
+export interface PlaceholderSpan {
+  index: number;
+  start: number;
+  end: number;
+}
+
+export function buildPlaceholder(index: number): string {
+  if (!Number.isSafeInteger(index) || index < 0) {
+    throw new RangeError(`placeholder index must be a non-negative safe integer, got ${index}`);
+  }
+  return `${PLACEHOLDER_OPEN}${index}${PLACEHOLDER_CLOSE}`;
+}
+
+export function containsPlaceholder(text: string): boolean {
+  for (let i = 0; i < text.length; i++) {
+    if (text.charCodeAt(i) === OPEN) return true;
+  }
+  return false;
+}
+
+export function findPlaceholders(text: string): PlaceholderSpan[] {
+  const spans: PlaceholderSpan[] = [];
+  let i = 0;
+  while (i < text.length) {
+    if (text.charCodeAt(i) !== OPEN) {
+      i += 1;
+      continue;
+    }
+    let j = i + 1;
+    let index = 0;
+    let digits = 0;
+    while (j < text.length) {
+      const code = text.charCodeAt(j);
+      if (code >= 0x30 && code <= 0x39) {
+        index = index * 10 + (code - 0x30);
+        digits += 1;
+        j += 1;
+      } else {
+        break;
+      }
+    }
+    if (digits > 0 && j < text.length && text.charCodeAt(j) === CLOSE) {
+      spans.push({ index, start: i, end: j + 1 });
+      i = j + 1;
+    } else {
+      i = j;
+    }
+  }
+  return spans;
+}
+
+/**
+ * Splits text into plain chunks and placeholder spans so a renderer can
+ * interleave restored components with the surrounding text.
+ */
+export function splitByPlaceholders(text: string): ReadonlyArray<string | PlaceholderSpan> {
+  if (text.length === 0) return [];
+  const parts: Array<string | PlaceholderSpan> = [];
+  let last = 0;
+  for (const span of findPlaceholders(text)) {
+    if (span.start > last) parts.push(text.slice(last, span.start));
+    parts.push(span);
+    last = span.end;
+  }
+  if (last < text.length) parts.push(text.slice(last));
+  return parts;
+}

--- a/wetty-chat-mobile/src/utils/markdown/preview.tsx
+++ b/wetty-chat-mobile/src/utils/markdown/preview.tsx
@@ -41,20 +41,14 @@ function previewBlocks(tokens: readonly Token[], options: MarkdownRenderOptions)
     switch (token.type) {
       case 'paragraph_open': {
         const closeIndex = findMatchingTokenEnd(tokens, i);
-        const content = renderInlineTokens(
-          inlineChildrenOf(tokens.slice(i + 1, closeIndex)),
-          options,
-        );
+        const content = renderInlineTokens(inlineChildrenOf(tokens.slice(i + 1, closeIndex)), options);
         addUnit(content);
         i = closeIndex + 1;
         break;
       }
       case 'heading_open': {
         const closeIndex = findMatchingTokenEnd(tokens, i);
-        const content = renderInlineTokens(
-          inlineChildrenOf(tokens.slice(i + 1, closeIndex)),
-          options,
-        );
+        const content = renderInlineTokens(inlineChildrenOf(tokens.slice(i + 1, closeIndex)), options);
         addUnit(createElement('strong', null, content));
         i = closeIndex + 1;
         break;
@@ -123,10 +117,7 @@ function previewBlocks(tokens: readonly Token[], options: MarkdownRenderOptions)
   return parts;
 }
 
-export function renderMarkdownPreview(
-  text: string,
-  options: MarkdownRenderOptions = {},
-): ReactNode[] {
+export function renderMarkdownPreview(text: string, options: MarkdownRenderOptions = {}): ReactNode[] {
   if (!text) return [];
   const singleLine: MarkdownRenderOptions = { ...options, singleLine: true };
   return previewBlocks(markdownEngine.parse(text, {}), singleLine);

--- a/wetty-chat-mobile/src/utils/markdown/preview.tsx
+++ b/wetty-chat-mobile/src/utils/markdown/preview.tsx
@@ -1,0 +1,133 @@
+import { Fragment, createElement } from 'react';
+import type { ReactNode } from 'react';
+import type { Token } from 'markdown-it';
+
+import { markdownEngine } from './engine';
+import { findMatchingTokenEnd, renderInlineTokens } from './react-renderer';
+import type { MarkdownRenderOptions } from './react-renderer';
+
+/**
+ * Single-line Markdown preview: flattens block structure into inline content
+ * so chat-list / thread previews can show rendered Markdown on one line. Line
+ * breaks become spaces; truncation is left to CSS rather than slicing raw text
+ * mid-marker.
+ */
+
+function inlineChildrenOf(inner: readonly Token[]): Token[] {
+  const children: Token[] = [];
+  for (const token of inner) {
+    if (token.type === 'inline') {
+      if (token.children) children.push(...token.children);
+    } else {
+      children.push(token);
+    }
+  }
+  return children;
+}
+
+function previewBlocks(tokens: readonly Token[], options: MarkdownRenderOptions): ReactNode[] {
+  const parts: ReactNode[] = [];
+  let unitNo = 0;
+
+  const addUnit = (content: ReactNode): void => {
+    if (unitNo > 0) parts.push(' ');
+    parts.push(createElement(Fragment, { key: unitNo }, content));
+    unitNo += 1;
+  };
+
+  let i = 0;
+  while (i < tokens.length) {
+    const token = tokens[i];
+    switch (token.type) {
+      case 'paragraph_open': {
+        const closeIndex = findMatchingTokenEnd(tokens, i);
+        const content = renderInlineTokens(
+          inlineChildrenOf(tokens.slice(i + 1, closeIndex)),
+          options,
+        );
+        addUnit(content);
+        i = closeIndex + 1;
+        break;
+      }
+      case 'heading_open': {
+        const closeIndex = findMatchingTokenEnd(tokens, i);
+        const content = renderInlineTokens(
+          inlineChildrenOf(tokens.slice(i + 1, closeIndex)),
+          options,
+        );
+        addUnit(createElement('strong', null, content));
+        i = closeIndex + 1;
+        break;
+      }
+      case 'bullet_list_open':
+      case 'ordered_list_open': {
+        const ordered = token.type === 'ordered_list_open';
+        const closeIndex = findMatchingTokenEnd(tokens, i);
+        const inner = tokens.slice(i + 1, closeIndex);
+
+        let itemNumber = 1;
+        if (ordered) {
+          const start = token.attrGet('start');
+          const startNumber = start == null ? NaN : Number(start);
+          if (Number.isInteger(startNumber) && startNumber >= 1) itemNumber = startNumber;
+        }
+
+        const listNodes: ReactNode[] = [];
+        let j = 0;
+        while (j < inner.length) {
+          if (inner[j].type !== 'list_item_open') {
+            j += 1;
+            continue;
+          }
+          const itemEnd = findMatchingTokenEnd(inner, j);
+          const itemContent = previewBlocks(inner.slice(j + 1, itemEnd), options);
+          if (listNodes.length > 0) listNodes.push(' ');
+          listNodes.push(ordered ? `${itemNumber}. ` : '• ');
+          listNodes.push(createElement(Fragment, { key: `li-${j}` }, itemContent));
+          itemNumber += 1;
+          j = itemEnd + 1;
+        }
+        addUnit(listNodes);
+        i = closeIndex + 1;
+        break;
+      }
+      case 'blockquote_open': {
+        const closeIndex = findMatchingTokenEnd(tokens, i);
+        addUnit(previewBlocks(tokens.slice(i + 1, closeIndex), options));
+        i = closeIndex + 1;
+        break;
+      }
+      case 'fence':
+      case 'code_block': {
+        const text = token.content.replace(/\s*\n+\s*/g, ' ').trim();
+        if (text) addUnit(createElement('code', null, text));
+        i += 1;
+        break;
+      }
+      case 'inline': {
+        addUnit(renderInlineTokens(token.children ?? [], options));
+        i += 1;
+        break;
+      }
+      default: {
+        if (token.type.endsWith('_open')) {
+          const closeIndex = findMatchingTokenEnd(tokens, i);
+          addUnit(previewBlocks(tokens.slice(i + 1, closeIndex), options));
+          i = closeIndex + 1;
+        } else {
+          i += 1;
+        }
+      }
+    }
+  }
+  return parts;
+}
+
+export function renderMarkdownPreview(
+  text: string,
+  options: MarkdownRenderOptions = {},
+): ReactNode[] {
+  if (!text) return [];
+  const singleLine: MarkdownRenderOptions = { ...options, singleLine: true };
+  return previewBlocks(markdownEngine.parse(text, {}), singleLine);
+}

--- a/wetty-chat-mobile/src/utils/markdown/react-renderer.test.tsx
+++ b/wetty-chat-mobile/src/utils/markdown/react-renderer.test.tsx
@@ -1,0 +1,212 @@
+import { Fragment, createElement } from 'react';
+import type { ReactNode } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { buildPlaceholder } from './placeholder';
+import { renderMarkdownPreview } from './preview';
+import { renderMarkdownText } from './react-renderer';
+import type { MarkdownRenderOptions } from './react-renderer';
+
+function staticMarkup(nodes: ReactNode[]): string {
+  return renderToStaticMarkup(createElement(Fragment, null, nodes));
+}
+
+function renderText(markdown: string, options?: MarkdownRenderOptions): string {
+  return staticMarkup(renderMarkdownText(markdown, options));
+}
+
+describe('renderMarkdownText — inline', () => {
+  it('renders bold, italic, strikethrough and inline code', () => {
+    expect(renderText('**bold** *italic* ~~strike~~ `code`')).toContain(
+      '<p><strong>bold</strong> <em>italic</em> <s>strike</s> <code>code</code></p>',
+    );
+  });
+
+  it('renders underline from double underscores', () => {
+    expect(renderText('__under__')).toBe('<p><u>under</u></p>');
+    expect(renderText('__a__ and **b**')).toBe('<p><u>a</u> and <strong>b</strong></p>');
+  });
+
+  it('renders single underscore markers as literal text', () => {
+    expect(renderText('_literal_ and __under__')).toBe('<p>_literal_ and <u>under</u></p>');
+  });
+
+  it('renders nested emphasis', () => {
+    expect(renderText('**bold and *nested***')).toContain('<strong>bold and <em>nested</em></strong>');
+  });
+
+  it('does not parse markers inside inline code', () => {
+    expect(renderText('`**x**`')).toBe('<p><code>**x**</code></p>');
+  });
+
+  it('escapes raw HTML instead of executing it', () => {
+    expect(renderText('<em>x</em>')).toBe('<p>&lt;em&gt;x&lt;/em&gt;</p>');
+    expect(renderText('<script>alert(1)</script>')).not.toContain('<script>');
+  });
+
+  it('keeps single newlines inside a paragraph', () => {
+    expect(renderText('line one\nline two')).toBe('<p>line one\nline two</p>');
+  });
+});
+
+describe('renderMarkdownText — links and images', () => {
+  it('renders explicit links with safe target and rel', () => {
+    const html = renderText('[example](https://example.com/path?q=1)');
+    expect(html).toContain('<a href="https://example.com/path?q=1"');
+    expect(html).toContain('target="_blank"');
+    expect(html).toContain('rel="noopener noreferrer"');
+    expect(html).toContain('>example</a>');
+  });
+
+  it('renders linkified bare URLs as links', () => {
+    expect(renderText('visit https://example.com/x today')).toContain(
+      '<a href="https://example.com/x" target="_blank" rel="noopener noreferrer">https://example.com/x</a>',
+    );
+  });
+
+  it('downgrades javascript: and relative hrefs to plain label text', () => {
+    // javascript: is rejected by the parser itself and stays literal text…
+    const js = renderText('[x](javascript:alert(1))');
+    expect(js).not.toContain('<a');
+    expect(js).not.toContain('href');
+    // …while non-http(s) schemes pass parsing but lose the anchor here.
+    expect(renderText('[mail](mailto:a@b.com)')).toBe('<p>mail</p>');
+    expect(renderText('[local](/m/abc)')).toBe('<p>local</p>');
+  });
+
+  it('shows image macros as literal text instead of <img>', () => {
+    // Image syntax is out of the allowlist, so the macro stays visible verbatim.
+    const html = renderText('![diagram](diagram.png)');
+    expect(html).not.toContain('<img');
+    expect(html).toContain('![diagram](diagram.png)');
+  });
+
+  it('keeps unsafe image sources as literal text', () => {
+    // `javascript:` is rejected by the parser, so the whole construct stays text.
+    const html = renderText('![alt](javascript:alert(1))');
+    expect(html).not.toContain('<a');
+    expect(html).not.toContain('<img');
+    expect(html).toBe('<p>![alt](javascript:alert(1))</p>');
+  });
+
+  it('invokes renderLink hook for custom anchors', () => {
+    const html = renderText('[inv](https://inv.example/x)', {
+      renderLink: (href, label) => createElement('span', { className: 'card', 'data-href': href }, label),
+    });
+    expect(html).toContain('<span class="card" data-href="https://inv.example/x">inv</span>');
+  });
+});
+
+describe('renderMarkdownText — placeholders', () => {
+  it('restores placeholders at their original positions', () => {
+    const text = `Hi ${buildPlaceholder(0)} and **bold** after ${buildPlaceholder(1)}!`;
+    const html = renderText(text, {
+      onPlaceholder: (index) => createElement('span', { className: 'mention' }, index === 0 ? '@alice' : '@bob'),
+    });
+    expect(html).toBe(
+      '<p>Hi <span class="mention">@alice</span> and <strong>bold</strong> after <span class="mention">@bob</span>!</p>',
+    );
+  });
+
+  it('drops placeholders when no restore hook is provided', () => {
+    expect(renderText(`a${buildPlaceholder(2)}b`)).toBe('<p>ab</p>');
+  });
+
+  it('restores placeholders nested inside emphasis', () => {
+    const html = renderText(`**hi ${buildPlaceholder(0)}**`, {
+      onPlaceholder: () => '@alice',
+    });
+    expect(html).toBe('<p><strong>hi @alice</strong></p>');
+  });
+});
+
+describe('renderMarkdownText — blocks', () => {
+  it('renders supported blocks and keeps headings and hr literal', () => {
+    const html = renderText('# Title\n\n> Quote **bold**\n\n- a\n- b\n\n---\n');
+    // Heading and horizontal-rule syntax are out of the allowlist.
+    expect(html).toContain('<p># Title</p>');
+    expect(html).not.toContain('<h1');
+    expect(html).toContain('<blockquote><p>Quote <strong>bold</strong></p></blockquote>');
+    // Tight lists must not wrap items in <p>.
+    expect(html).toContain('<ul><li>a</li><li>b</li></ul>');
+    expect(html).not.toContain('<hr');
+    expect(html).toContain('<p>---</p>');
+  });
+
+  it('renders ordered lists and keeps an explicit start attribute', () => {
+    expect(renderText('3. three\n4. four')).toContain('<ol start="3"><li>three</li><li>four</li></ol>');
+    expect(renderText('1. one\n2. two')).toContain('<ol><li>one</li><li>two</li></ol>');
+  });
+
+  it('renders nested lists', () => {
+    const html = renderText('- a\n  - nested\n- b');
+    expect(html).toContain('<ul><li>a<ul><li>nested</li></ul></li><li>b</li></ul>');
+  });
+
+  it('renders fenced code with a sanitized language class', () => {
+    const html = renderText('```ts\nconst a = 1;\n```');
+    expect(html).toContain('<pre><code class="language-ts">const a = 1;');
+    expect(html).toContain('</code></pre>');
+  });
+
+  it('escapes code fence content and drops unsafe language classes', () => {
+    const html = renderText('```"><img onerror=1>\n<b>raw</b>\n```');
+    expect(html).not.toContain('language-');
+    expect(html).not.toContain('<b>raw</b>');
+    expect(html).toContain('&lt;b&gt;raw&lt;/b&gt;');
+  });
+
+  it('treats indented code as literal paragraph text', () => {
+    const html = renderText('    indented code');
+    expect(html).not.toContain('<pre>');
+    expect(html).toContain('indented code');
+  });
+
+  it('wraps loose list items in paragraphs', () => {
+    const html = renderText('- first\n\n- second');
+    expect(html).toContain('<li><p>first</p></li>');
+  });
+
+  it('renders multiple paragraphs separately', () => {
+    expect(renderText('one\n\ntwo')).toBe('<p>one</p><p>two</p>');
+  });
+});
+
+describe('renderMarkdownPreview — single line', () => {
+  it('flattens inline formatting onto one line', () => {
+    expect(staticMarkup(renderMarkdownPreview('**bold** and `code`'))).toBe(
+      '<strong>bold</strong> and <code>code</code>',
+    );
+  });
+
+  it('collapses line breaks to spaces', () => {
+    expect(staticMarkup(renderMarkdownPreview('l1\nl2'))).toBe('l1 l2');
+  });
+
+  it('keeps headings literal on one line', () => {
+    expect(staticMarkup(renderMarkdownPreview('# Title\n\nBody'))).toBe('# Title Body');
+  });
+
+  it('flattens lists with bullets and order markers', () => {
+    expect(staticMarkup(renderMarkdownPreview('- one\n- two'))).toBe('• one • two');
+    expect(staticMarkup(renderMarkdownPreview('3. three\n4. four'))).toBe('3. three 4. four');
+  });
+
+  it('flattens blockquotes and code blocks', () => {
+    expect(staticMarkup(renderMarkdownPreview('> quoted\n\nrest'))).toBe('quoted rest');
+    expect(staticMarkup(renderMarkdownPreview('```\na\nb\n```'))).toBe('<code>a b</code>');
+  });
+
+  it('drops empty output but keeps rule text literal', () => {
+    expect(staticMarkup(renderMarkdownPreview(''))).toBe('');
+    expect(staticMarkup(renderMarkdownPreview('---'))).toBe('---');
+  });
+
+  it('restores placeholders in previews too', () => {
+    const nodes = renderMarkdownPreview(`see ${buildPlaceholder(0)} now`, {
+      onPlaceholder: () => '@alice',
+    });
+    expect(renderToStaticMarkup(createElement(Fragment, null, nodes))).toBe('see @alice now');
+  });
+});

--- a/wetty-chat-mobile/src/utils/markdown/react-renderer.tsx
+++ b/wetty-chat-mobile/src/utils/markdown/react-renderer.tsx
@@ -1,0 +1,339 @@
+import { Fragment, createElement } from 'react';
+import type { ReactNode } from 'react';
+import type { Token } from 'markdown-it';
+
+import { markdownEngine } from './engine';
+import { containsPlaceholder, splitByPlaceholders } from './placeholder';
+
+/**
+ * Renders a markdown-it token stream as controlled React elements — never HTML
+ * strings, never `dangerouslySetInnerHTML` — so raw HTML and `javascript:`-style
+ * payloads stay inert. Interactive widgets (mentions / invite cards /
+ * permalinks) are re-inserted at their placeholder slots inside `text` tokens
+ * via {@link MarkdownRenderOptions.onPlaceholder}.
+ */
+export interface MarkdownRenderOptions {
+  /** Restores a placeholder slot to its widget; not called for code content. */
+  onPlaceholder?: (index: number) => ReactNode | null | undefined;
+  /**
+   * Custom anchor hook (invite / permalink widgets). Return `null`/`undefined`
+   * to fall back to the default safe external anchor.
+   */
+  renderLink?: (href: string, label: ReactNode, token: Token) => ReactNode | null | undefined;
+  /** Single-line context (chat-list previews): line breaks become spaces. */
+  singleLine?: boolean;
+}
+
+/** Only absolute `http:`/`https:` hrefs may become links. */
+export function isSafeLinkHref(href: string | null | undefined): href is string {
+  if (!href) return false;
+  return /^https?:\/\//i.test(href);
+}
+
+const stopPropagation = (event: { stopPropagation(): void }): void => {
+  event.stopPropagation();
+};
+
+const HEADING_TAGS = new Set(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']);
+type HeadingTag = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+
+/**
+ * Index of the token closing the container opened at `openIndex`, skipping
+ * balanced nested containers of the same type.
+ *
+ * @internal exported for `preview.tsx`.
+ */
+export function findMatchingTokenEnd(tokens: readonly Token[], openIndex: number): number {
+  const openType = tokens[openIndex]?.type ?? '';
+  const closeType = openType.replace(/_open$/, '_close');
+  let depth = 0;
+  for (let i = openIndex; i < tokens.length; i++) {
+    const type = tokens[i].type;
+    if (type === openType) {
+      depth += 1;
+    } else if (type === closeType) {
+      depth -= 1;
+      if (depth === 0) return i;
+    }
+  }
+  return tokens.length - 1;
+}
+
+function pushTextNodes(out: ReactNode[], text: string, options: MarkdownRenderOptions, nextKey: () => number): void {
+  if (!text) return;
+  if (!containsPlaceholder(text)) {
+    out.push(text);
+    return;
+  }
+  for (const part of splitByPlaceholders(text)) {
+    if (typeof part === 'string') {
+      if (part) out.push(part);
+      continue;
+    }
+    const node = options.onPlaceholder?.(part.index);
+    if (node != null) {
+      // Keyed Fragment: sibling keys stay unique even if the widget brings keys.
+      out.push(createElement(Fragment, { key: nextKey() }, node));
+    }
+  }
+}
+
+export function renderInlineTokens(tokens: readonly Token[], options: MarkdownRenderOptions = {}): ReactNode[] {
+  const out: ReactNode[] = [];
+  let keyCounter = 0;
+  const nextKey = () => keyCounter++;
+
+  let i = 0;
+  while (i < tokens.length) {
+    const token = tokens[i];
+    switch (token.type) {
+      case 'text': {
+        pushTextNodes(out, token.content, options, nextKey);
+        i += 1;
+        break;
+      }
+      case 'softbreak':
+      case 'hardbreak': {
+        out.push(options.singleLine ? ' ' : '\n');
+        i += 1;
+        break;
+      }
+      case 'code_inline': {
+        out.push(createElement('code', { key: nextKey() }, token.content));
+        i += 1;
+        break;
+      }
+      case 'image': {
+        const rawSrc = token.attrGet('src');
+        const src = typeof rawSrc === 'string' ? rawSrc : null;
+        const label = token.content || src || '';
+        if (isSafeLinkHref(src)) {
+          out.push(
+            createElement(
+              'a',
+              {
+                key: nextKey(),
+                href: src,
+                target: '_blank',
+                rel: 'noopener noreferrer',
+                onClick: stopPropagation,
+              },
+              label,
+            ),
+          );
+        } else if (label) {
+          // Unsafe src: render the alt text only.
+          out.push(label);
+        }
+        i += 1;
+        break;
+      }
+      case 'em_open':
+      case 'strong_open':
+      case 's_open':
+      case 'u_open': {
+        const closeIndex = findMatchingTokenEnd(tokens, i);
+        const tag =
+          token.type === 'em_open'
+            ? 'em'
+            : token.type === 'strong_open'
+              ? 'strong'
+              : token.type === 's_open'
+                ? 's'
+                : 'u';
+        const inner = renderInlineTokens(tokens.slice(i + 1, closeIndex), options);
+        out.push(createElement(tag, { key: nextKey() }, inner));
+        i = closeIndex + 1;
+        break;
+      }
+      case 'link_open': {
+        const closeIndex = findMatchingTokenEnd(tokens, i);
+        const rawHref = token.attrGet('href');
+        const href = typeof rawHref === 'string' ? rawHref : null;
+        const label = renderInlineTokens(tokens.slice(i + 1, closeIndex), options);
+        const key = nextKey();
+        if (isSafeLinkHref(href)) {
+          const custom = options.renderLink?.(href, label, token);
+          if (custom != null) {
+            out.push(createElement(Fragment, { key }, custom));
+          } else {
+            out.push(
+              createElement(
+                'a',
+                {
+                  key,
+                  href,
+                  target: '_blank',
+                  rel: 'noopener noreferrer',
+                  onClick: stopPropagation,
+                },
+                label,
+              ),
+            );
+          }
+        } else {
+          // Downgrade unsafe / relative hrefs to plain text.
+          out.push(createElement(Fragment, { key }, label));
+        }
+        i = closeIndex + 1;
+        break;
+      }
+      case 'html_inline': {
+        pushTextNodes(out, token.content, options, nextKey);
+        i += 1;
+        break;
+      }
+      default: {
+        if (token.type.endsWith('_open')) {
+          // Unknown container: keep its content without a wrapper.
+          const closeIndex = findMatchingTokenEnd(tokens, i);
+          const inner = renderInlineTokens(tokens.slice(i + 1, closeIndex), options);
+          out.push(createElement(Fragment, { key: nextKey() }, inner));
+          i = closeIndex + 1;
+        } else {
+          pushTextNodes(out, token.content, options, nextKey);
+          i += 1;
+        }
+      }
+    }
+  }
+  return out;
+}
+
+function blockInlineContent(inner: readonly Token[], options: MarkdownRenderOptions): ReactNode[] {
+  const children: Token[] = [];
+  for (const token of inner) {
+    if (token.type === 'inline') {
+      if (token.children) children.push(...token.children);
+    } else {
+      children.push(token);
+    }
+  }
+  return renderInlineTokens(children, options);
+}
+
+function listItemSlices(inner: readonly Token[]): Token[][] {
+  const items: Token[][] = [];
+  let i = 0;
+  while (i < inner.length) {
+    if (inner[i].type !== 'list_item_open') {
+      i += 1;
+      continue;
+    }
+    const closeIndex = findMatchingTokenEnd(inner, i);
+    items.push(inner.slice(i + 1, closeIndex));
+    i = closeIndex + 1;
+  }
+  return items;
+}
+
+function renderList(tokens: readonly Token[], openIndex: number, options: MarkdownRenderOptions): ReactNode {
+  const token = tokens[openIndex];
+  const closeIndex = findMatchingTokenEnd(tokens, openIndex);
+  const items = listItemSlices(tokens.slice(openIndex + 1, closeIndex));
+  const tag = token.type === 'ordered_list_open' ? 'ol' : 'ul';
+  const ordered = token.type === 'ordered_list_open';
+
+  const props: { start?: number; key: number } = { key: openIndex };
+  if (ordered) {
+    const start = token.attrGet('start');
+    const startNumber = start == null ? NaN : Number(start);
+    // The default renderer only emits `start` when it differs from 1.
+    if (Number.isInteger(startNumber) && startNumber !== 1) props.start = startNumber;
+  }
+
+  return createElement(
+    tag,
+    props,
+    items.map((slice, index) => createElement('li', { key: index }, renderBlocks(slice, options))),
+  );
+}
+
+function renderBlocks(tokens: readonly Token[], options: MarkdownRenderOptions): ReactNode[] {
+  const out: ReactNode[] = [];
+  let i = 0;
+  while (i < tokens.length) {
+    const token = tokens[i];
+    switch (token.type) {
+      case 'paragraph_open': {
+        const closeIndex = findMatchingTokenEnd(tokens, i);
+        const content = blockInlineContent(tokens.slice(i + 1, closeIndex), options);
+        // Tight list paragraphs carry `hidden: true` and must not wrap <p>.
+        out.push(token.hidden ? createElement(Fragment, { key: i }, content) : createElement('p', { key: i }, content));
+        i = closeIndex + 1;
+        break;
+      }
+      case 'heading_open': {
+        const closeIndex = findMatchingTokenEnd(tokens, i);
+        const tag = token.tag;
+        const content = blockInlineContent(tokens.slice(i + 1, closeIndex), options);
+        out.push(createElement(HEADING_TAGS.has(tag) ? (tag as HeadingTag) : 'p', { key: i }, content));
+        i = closeIndex + 1;
+        break;
+      }
+      case 'bullet_list_open':
+      case 'ordered_list_open': {
+        out.push(renderList(tokens, i, options));
+        i = findMatchingTokenEnd(tokens, i) + 1;
+        break;
+      }
+      case 'blockquote_open': {
+        const closeIndex = findMatchingTokenEnd(tokens, i);
+        const inner = renderBlocks(tokens.slice(i + 1, closeIndex), options);
+        out.push(createElement('blockquote', { key: i }, inner));
+        i = closeIndex + 1;
+        break;
+      }
+      case 'fence':
+      case 'code_block': {
+        const language = token.info.trim().split(/\s+/, 1)[0];
+        const className = language && /^[\w+-]+$/.test(language) ? `language-${language}` : undefined;
+        const code = createElement('code', className ? { className } : null, token.content);
+        out.push(createElement('pre', { key: i }, code));
+        i += 1;
+        break;
+      }
+      case 'hr': {
+        out.push(createElement('hr', { key: i }));
+        i += 1;
+        break;
+      }
+      case 'inline': {
+        out.push(...renderInlineTokens(token.children ?? [], options));
+        i += 1;
+        break;
+      }
+      case 'html_block': {
+        const nodes: ReactNode[] = [];
+        pushTextNodes(nodes, token.content, options, () => {
+          const key = nodes.length;
+          return key;
+        });
+        out.push(createElement(Fragment, { key: i }, nodes));
+        i += 1;
+        break;
+      }
+      default: {
+        if (token.type.endsWith('_open')) {
+          const closeIndex = findMatchingTokenEnd(tokens, i);
+          out.push(createElement(Fragment, { key: i }, renderBlocks(tokens.slice(i + 1, closeIndex), options)));
+          i = closeIndex + 1;
+        } else {
+          const nodes: ReactNode[] = [];
+          pushTextNodes(nodes, token.content, options, () => nodes.length);
+          out.push(...nodes);
+          i += 1;
+        }
+      }
+    }
+  }
+  return out;
+}
+
+export function renderMarkdownTokens(tokens: readonly Token[], options: MarkdownRenderOptions = {}): ReactNode[] {
+  return renderBlocks(tokens, options);
+}
+
+export function renderMarkdownText(text: string, options: MarkdownRenderOptions = {}): ReactNode[] {
+  return renderMarkdownTokens(markdownEngine.parse(text, {}), options);
+}

--- a/wetty-chat-mobile/src/utils/markdown/rules.ts
+++ b/wetty-chat-mobile/src/utils/markdown/rules.ts
@@ -139,10 +139,7 @@ function underlinePostProcess(state: StateInline, delimiters: StateInline['delim
     token.nesting = -1;
     token.markup = '__';
     token.content = '';
-    if (
-      state.tokens[endDelim.token - 1].type === 'text' &&
-      state.tokens[endDelim.token - 1].content === '_'
-    ) {
+    if (state.tokens[endDelim.token - 1].type === 'text' && state.tokens[endDelim.token - 1].content === '_') {
       loneMarkers.push(endDelim.token - 1);
     }
   }

--- a/wetty-chat-mobile/src/utils/markdown/rules.ts
+++ b/wetty-chat-mobile/src/utils/markdown/rules.ts
@@ -1,0 +1,253 @@
+import type { MarkdownIt, StateBlock, StateInline } from 'markdown-it';
+
+/**
+ * Custom inline rules for chahua's Markdown subset. markdown-it's default
+ * emphasis treats both `*` and `_` as markers; chahua keeps `*` / `**` for
+ * emphasis only and repurposes `__…__` as underline (`<u>`), leaving single
+ * `_` literal. `~~strike~~` keeps markdown-it's stock rule.
+ *
+ * `emphasis` is re-registered with a `*`-only clone of markdown-it's own
+ * machinery; `underline` is a new rule modelled on its strikethrough.
+ */
+
+const STAR = 0x2a; // *
+const UNDERLINE = 0x5f; // _
+
+/* ---------------------------------------------------------------------------
+ * `*` / `**` emphasis — clone of markdown-it's rules_inline/emphasis.ts,
+ * restricted to the `*` marker.
+ * ------------------------------------------------------------------------- */
+
+function starEmphasisTokenize(state: StateInline, silent: boolean): boolean {
+  if (silent) return false;
+  const marker = state.src.charCodeAt(state.pos);
+  if (marker !== STAR) return false;
+  const scanned = state.scanDelims(state.pos, true);
+  for (let i = 0; i < scanned.length; i++) {
+    const token = state.push('text', '', 0);
+    token.content = String.fromCharCode(marker);
+    state.delimiters.push({
+      marker,
+      length: scanned.length,
+      token: state.tokens.length - 1,
+      end: -1,
+      open: scanned.can_open,
+      close: scanned.can_close,
+    });
+  }
+  state.pos += scanned.length;
+  return true;
+}
+
+function starEmphasisPostProcess(state: StateInline, delimiters: StateInline['delimiters']): void {
+  const max = delimiters.length;
+  for (let i = max - 1; i >= 0; i--) {
+    const startDelim = delimiters[i];
+    if (startDelim.marker !== STAR) continue;
+    if (startDelim.end === -1) continue;
+    const endDelim = delimiters[startDelim.end];
+    const isStrong =
+      i > 0 &&
+      delimiters[i - 1].end === startDelim.end + 1 &&
+      delimiters[i - 1].marker === startDelim.marker &&
+      delimiters[i - 1].token === startDelim.token - 1 &&
+      delimiters[startDelim.end + 1].token === endDelim.token + 1;
+    const ch = String.fromCharCode(startDelim.marker);
+    const tokenOpen = state.tokens[startDelim.token];
+    tokenOpen.type = isStrong ? 'strong_open' : 'em_open';
+    tokenOpen.tag = isStrong ? 'strong' : 'em';
+    tokenOpen.nesting = 1;
+    tokenOpen.markup = isStrong ? ch + ch : ch;
+    tokenOpen.content = '';
+    const tokenClose = state.tokens[endDelim.token];
+    tokenClose.type = isStrong ? 'strong_close' : 'em_close';
+    tokenClose.tag = isStrong ? 'strong' : 'em';
+    tokenClose.nesting = -1;
+    tokenClose.markup = isStrong ? ch + ch : ch;
+    tokenClose.content = '';
+    if (isStrong) {
+      state.tokens[delimiters[i - 1].token].content = '';
+      state.tokens[delimiters[startDelim.end + 1].token].content = '';
+      i--;
+    }
+  }
+}
+
+function starEmphasisPost(state: StateInline): void {
+  const tokensMeta = state.tokens_meta;
+  const max = state.tokens_meta.length;
+  starEmphasisPostProcess(state, state.delimiters);
+  for (let curr = 0; curr < max; curr++) {
+    const delimiters = tokensMeta[curr]?.delimiters;
+    if (delimiters) starEmphasisPostProcess(state, delimiters);
+  }
+}
+
+/* ---------------------------------------------------------------------------
+ * `__` underline — clone of markdown-it's rules_inline/strikethrough.ts using
+ * the `_` marker. Single `_` is not tokenized and stays literal text.
+ * ------------------------------------------------------------------------- */
+
+function underlineTokenize(state: StateInline, silent: boolean): boolean {
+  if (silent) return false;
+  const marker = state.src.charCodeAt(state.pos);
+  if (marker !== UNDERLINE) return false;
+  const scanned = state.scanDelims(state.pos, true);
+  let len = scanned.length;
+  const ch = String.fromCharCode(marker);
+  if (len < 2) return false;
+  let token;
+  if (len % 2) {
+    token = state.push('text', '', 0);
+    token.content = ch;
+    len--;
+  }
+  for (let i = 0; i < len; i += 2) {
+    token = state.push('text', '', 0);
+    token.content = ch + ch;
+    state.delimiters.push({
+      marker,
+      length: 0,
+      token: state.tokens.length - 1,
+      end: -1,
+      open: scanned.can_open,
+      close: scanned.can_close,
+    });
+  }
+  state.pos += scanned.length;
+  return true;
+}
+
+function underlinePostProcess(state: StateInline, delimiters: StateInline['delimiters']): void {
+  let token;
+  const loneMarkers: number[] = [];
+  const max = delimiters.length;
+  for (let i = 0; i < max; i++) {
+    const startDelim = delimiters[i];
+    if (startDelim.marker !== UNDERLINE) continue;
+    if (startDelim.end === -1) continue;
+    const endDelim = delimiters[startDelim.end];
+    token = state.tokens[startDelim.token];
+    token.type = 'u_open';
+    token.tag = 'u';
+    token.nesting = 1;
+    token.markup = '__';
+    token.content = '';
+    token = state.tokens[endDelim.token];
+    token.type = 'u_close';
+    token.tag = 'u';
+    token.nesting = -1;
+    token.markup = '__';
+    token.content = '';
+    if (
+      state.tokens[endDelim.token - 1].type === 'text' &&
+      state.tokens[endDelim.token - 1].content === '_'
+    ) {
+      loneMarkers.push(endDelim.token - 1);
+    }
+  }
+  while (loneMarkers.length) {
+    const i = loneMarkers.pop() as number;
+    let j = i + 1;
+    while (j < state.tokens.length && state.tokens[j].type === 'u_close') j++;
+    j--;
+    if (i !== j) {
+      token = state.tokens[j];
+      state.tokens[j] = state.tokens[i];
+      state.tokens[i] = token;
+    }
+  }
+}
+
+function underlinePost(state: StateInline): void {
+  const tokensMeta = state.tokens_meta;
+  const max = state.tokens_meta.length;
+  underlinePostProcess(state, state.delimiters);
+  for (let curr = 0; curr < max; curr++) {
+    const delimiters = tokensMeta[curr]?.delimiters;
+    if (delimiters) underlinePostProcess(state, delimiters);
+  }
+}
+
+/* ---------------------------------------------------------------------------
+ * Subset configuration for the whole engine.
+ * ------------------------------------------------------------------------- */
+
+/**
+ * Rules disabled so their syntax renders as literal text. Headings, horizontal
+ * rules, images, reference links, autolinks, HTML and entities are NOT part of
+ * chahua's subset.
+ */
+const DISABLED_RULES = [
+  // block
+  'table',
+  'code', // 4-space indented code block
+  'hr',
+  'reference',
+  'html_block',
+  'heading',
+  'lheading',
+  // inline
+  'image',
+  'autolink',
+  'html_inline',
+  'entity',
+];
+
+/* markdown-it keeps the block rules behind a semi-public Ruler instance. We
+ * only need it to swap the `list` rule, so poke through its `__rules__` list
+ * (an established pattern used by many markdown-it plugins). */
+interface InternalBlockRule {
+  name: string;
+  enabled: boolean;
+  fn: (state: StateBlock, startLine: number, endLine: number, silent: boolean) => boolean;
+  alt: string[];
+}
+interface BlockRulerInternals {
+  __rules__: InternalBlockRule[];
+}
+
+const SPACE = 0x20;
+const TAB = 0x09;
+
+/**
+ * Wraps the native `list` rule so a line starting with a `* ` bullet (or a
+ * lone `*`) is NOT a list. `*` is reserved for emphasis in chahua's subset;
+ * only `-` and `1.` start lists. Returning `false` lets the lower-priority
+ * rules (paragraph) render the line literally, in every context the native
+ * list rule is consulted (top level, inside blockquotes, nested items...).
+ */
+function starAwareListRule(
+  nativeList: InternalBlockRule['fn'],
+): (state: StateBlock, startLine: number, endLine: number, silent: boolean) => boolean {
+  return function listWithoutStarBullets(state, startLine, endLine, silent) {
+    const pos = state.bMarks[startLine] + state.tShift[startLine];
+    if (state.src.charCodeAt(pos) === STAR) {
+      const max = state.eMarks[startLine];
+      const after = pos + 1;
+      if (after >= max || state.src.charCodeAt(after) === SPACE || state.src.charCodeAt(after) === TAB) {
+        return false;
+      }
+    }
+    return nativeList(state, startLine, endLine, silent);
+  };
+}
+
+export function applyMarkdownSubset(md: MarkdownIt): void {
+  md.disable(DISABLED_RULES, true);
+
+  // `*`-only emphasis.
+  md.inline.ruler.at('emphasis', starEmphasisTokenize);
+  md.inline.ruler2.at('emphasis', starEmphasisPost);
+
+  // `__` underline (must pair after balance_pairs but before fragments_join).
+  md.inline.ruler.before('link', 'underline', underlineTokenize);
+  md.inline.ruler2.before('fragments_join', 'underline', underlinePost);
+
+  // `*` is not a list marker.
+  const ruler = md.block.ruler as unknown as BlockRulerInternals;
+  const listRule = ruler.__rules__.find((rule) => rule.name === 'list');
+  if (listRule) {
+    md.block.ruler.at('list', starAwareListRule(listRule.fn), { alt: listRule.alt });
+  }
+}

--- a/wetty-chat-mobile/src/utils/markdown/tokens.ts
+++ b/wetty-chat-mobile/src/utils/markdown/tokens.ts
@@ -1,0 +1,72 @@
+import type { Token } from 'markdown-it';
+
+/**
+ * Token types that route a message through the Markdown renderer. Messages
+ * producing none of them stay on the legacy plain-text path.
+ */
+const MEANINGFUL_TOKEN_TYPES = new Set<string>([
+  // Inline formatting
+  'em_open',
+  'strong_open',
+  's_open',
+  'u_open',
+  'code_inline',
+  'link_open',
+  'autolink',
+  'image',
+  // Block structure
+  'heading_open',
+  'bullet_list_open',
+  'ordered_list_open',
+  'blockquote_open',
+  'hr',
+  'fence',
+  'code_block',
+]);
+
+function walkTokens(tokens: readonly Token[], visit: (token: Token) => void, includeChildren: boolean): void {
+  for (const token of tokens) {
+    visit(token);
+    if (includeChildren && token.children) walkTokens(token.children, visit, true);
+  }
+}
+
+export function tokensContainMarkup(tokens: readonly Token[]): boolean {
+  let hit = false;
+  walkTokens(
+    tokens,
+    (token) => {
+      if (!hit && MEANINGFUL_TOKEN_TYPES.has(token.type)) hit = true;
+    },
+    true,
+  );
+  return hit;
+}
+
+/**
+ * True when the body needs block layout: a heading / list / quote / fence /
+ * code block / hr, or more than one paragraph. Purely inline formatting stays
+ * inline.
+ */
+export function tokensContainBlocks(tokens: readonly Token[]): boolean {
+  let paragraphs = 0;
+  for (const token of tokens) {
+    switch (token.type) {
+      case 'paragraph_open':
+        paragraphs += 1;
+        if (paragraphs > 1) return true;
+        break;
+      case 'heading_open':
+      case 'bullet_list_open':
+      case 'ordered_list_open':
+      case 'blockquote_open':
+      case 'hr':
+      case 'fence':
+      case 'code_block':
+        return true;
+      default:
+        break;
+    }
+  }
+  return false;
+}

--- a/wetty-chat-mobile/src/utils/textFormat.test.ts
+++ b/wetty-chat-mobile/src/utils/textFormat.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyLink,
+  normalizeLinkHref,
+  shortcutFormatKind,
+  wrapBlockFormat,
+  wrapInlineFormat,
+  type TextFormatKind,
+} from './textFormat';
+
+describe('wrapInlineFormat', () => {
+  const KINDS: Array<{ kind: TextFormatKind; open: string; close: string }> = [
+    { kind: 'bold', open: '**', close: '**' },
+    { kind: 'italic', open: '*', close: '*' },
+    { kind: 'strike', open: '~~', close: '~~' },
+    { kind: 'underline', open: '__', close: '__' },
+  ];
+
+  it.each(KINDS.map(({ kind, open, close }) => [kind, open, close]))(
+    'wraps %s selection and places the cursor after the closing marker',
+    (kind, open, close) => {
+      const result = wrapInlineFormat('say hello there', { start: 4, end: 9 }, kind as never);
+
+      expect(result).not.toBeNull();
+      expect(result!.text).toBe(`say ${open}hello${close} there`);
+      const inserted = `${open}hello${close}`;
+      expect(result!.selectionStart).toBe(4 + inserted.length);
+      expect(result!.selectionEnd).toBe(4 + inserted.length);
+    },
+  );
+
+  it('returns null for a collapsed selection (no stray markers)', () => {
+    expect(wrapInlineFormat('nothing selected', { start: 3, end: 3 }, 'bold')).toBeNull();
+    expect(wrapInlineFormat('nothing selected', { start: 3, end: 3 }, 'italic')).toBeNull();
+    expect(wrapInlineFormat('nothing selected', { start: 3, end: 3 }, 'strike')).toBeNull();
+    expect(wrapInlineFormat('nothing selected', { start: 3, end: 3 }, 'underline')).toBeNull();
+  });
+
+  it('clamps out-of-range selections to the text bounds', () => {
+    const result = wrapInlineFormat('abc', { start: -5, end: 99 }, 'bold');
+    expect(result!.text).toBe('**abc**');
+  });
+
+  it('keeps surrounding text intact when wrapping at the edges', () => {
+    const whole = wrapInlineFormat('abc', { start: 0, end: 3 }, 'italic');
+    expect(whole!.text).toBe('*abc*');
+    const prefix = wrapInlineFormat('abc', { start: 0, end: 1 }, 'bold');
+    expect(prefix!.text).toBe('**a**bc');
+  });
+});
+
+describe('wrapBlockFormat', () => {
+  it('wraps a selection in fenced code markers', () => {
+    const result = wrapBlockFormat('a\nconst x = 1;\nb', { start: 2, end: 14 }, 'code');
+    expect(result!.text).toBe('a\n```\nconst x = 1;\n```\nb');
+    expect(result!.selectionStart).toBe(result!.selectionEnd);
+  });
+
+  it('prefixes every selected line for a quote', () => {
+    const result = wrapBlockFormat('first\nsecond', { start: 0, end: 12 }, 'quote');
+    expect(result!.text).toBe('> first\n> second');
+  });
+
+  it('collapsed selection returns null (no stray prefixes)', () => {
+    expect(wrapBlockFormat('abc', { start: 1, end: 1 }, 'code')).toBeNull();
+    expect(wrapBlockFormat('abc', { start: 1, end: 1 }, 'quote')).toBeNull();
+  });
+});
+
+describe('applyLink', () => {
+  it('turns a selection into a Markdown link', () => {
+    // "docs" spans indexes 9..13 in "open the docs page now".
+    const result = applyLink('open the docs page now', { start: 9, end: 13 }, 'example.com');
+
+    expect(result.text).toBe('open the [docs](https://example.com) page now');
+    // Cursor collapses after the closing parenthesis.
+    expect(result.selectionStart).toBe(9 + '[docs](https://example.com)'.length);
+    expect(result.selectionEnd).toBe(result.selectionStart);
+  });
+
+  it('inserts the text placeholder and selects it when there is no selection', () => {
+    const result = applyLink('hello ', { start: 6, end: 6 }, 'https://example.com');
+
+    expect(result.text).toBe('hello [text](https://example.com)');
+    expect(result.selectionStart).toBe(7); // inside the `[text]` label
+    expect(result.selectionEnd).toBe(11);
+    expect(result.text.slice(result.selectionStart, result.selectionEnd)).toBe('text');
+  });
+
+  it('preserves explicit http(s) URLs', () => {
+    const result = applyLink('x', { start: 0, end: 1 }, 'HTTP://Example.COM/path?q=1');
+    expect(result.text).toBe('[x](HTTP://Example.COM/path?q=1)');
+  });
+
+  it('normalises an empty raw URL to https://', () => {
+    const result = applyLink('x', { start: 0, end: 1 }, '   ');
+    expect(result.text).toBe('[x](https://)');
+  });
+});
+
+describe('normalizeLinkHref', () => {
+  it('prefixes scheme-less input with https://', () => {
+    expect(normalizeLinkHref('example.com/path')).toBe('https://example.com/path');
+    expect(normalizeLinkHref('  example.com  ')).toBe('https://example.com');
+  });
+
+  it('keeps http/https schemes untouched', () => {
+    expect(normalizeLinkHref('https://example.com')).toBe('https://example.com');
+    expect(normalizeLinkHref('http://example.com')).toBe('http://example.com');
+  });
+
+  it('never returns an executable scheme', () => {
+    expect(normalizeLinkHref('javascript:alert(1)')).toBe('https://alert(1)');
+    expect(normalizeLinkHref('vbscript:msgbox(1)')).toBe('https://msgbox(1)');
+    expect(normalizeLinkHref('data:text/html,x')).toBe('https://text/html,x');
+  });
+});
+
+describe('shortcutFormatKind', () => {
+  it('maps Ctrl/Cmd + B / I / D / U / Q to the matching format', () => {
+    expect(shortcutFormatKind({ key: 'b' })).toBe('bold');
+    expect(shortcutFormatKind({ key: 'B' })).toBe('bold');
+    expect(shortcutFormatKind({ key: 'i' })).toBe('italic');
+    expect(shortcutFormatKind({ key: 'I' })).toBe('italic');
+    expect(shortcutFormatKind({ key: 'd' })).toBe('strike');
+    expect(shortcutFormatKind({ key: 'D' })).toBe('strike');
+    expect(shortcutFormatKind({ key: 'u' })).toBe('underline');
+    expect(shortcutFormatKind({ key: 'U' })).toBe('underline');
+    expect(shortcutFormatKind({ key: 'q' })).toBe('quote');
+    expect(shortcutFormatKind({ key: 'Q' })).toBe('quote');
+  });
+
+  it('returns null for unrelated keys', () => {
+    expect(shortcutFormatKind({ key: 'x' })).toBeNull();
+    expect(shortcutFormatKind({ key: 'Enter' })).toBeNull();
+  });
+});

--- a/wetty-chat-mobile/src/utils/textFormat.ts
+++ b/wetty-chat-mobile/src/utils/textFormat.ts
@@ -1,0 +1,141 @@
+/**
+ * Pure, DOM-free text-editing helpers for the composer's formatting toolbar.
+ * ComposeInput maps textarea selections to `TextSelection` and commits the
+ * returned text back into the controlled value.
+ */
+
+export type InlineFormatKind = 'bold' | 'italic' | 'strike' | 'underline';
+
+export type BlockFormatKind = 'code' | 'quote';
+
+export type TextFormatKind = InlineFormatKind | 'link' | BlockFormatKind;
+
+export interface TextSelection {
+  start: number;
+  end: number;
+}
+
+export interface TextFormatResult {
+  text: string;
+  selectionStart: number;
+  selectionEnd: number;
+}
+
+const WRAP_MARKERS: Record<InlineFormatKind, readonly [string, string]> = {
+  bold: ['**', '**'],
+  italic: ['*', '*'],
+  strike: ['~~', '~~'],
+  underline: ['__', '__'],
+};
+
+function clampSelection(text: string, selection: TextSelection): TextSelection {
+  const max = text.length;
+  const rawStart = Number.isFinite(selection.start) ? selection.start : 0;
+  const rawEnd = Number.isFinite(selection.end) ? selection.end : rawStart;
+  const start = Math.max(0, Math.min(rawStart, max));
+  const end = Math.max(start, Math.min(Math.max(rawEnd, rawStart), max));
+  return { start, end };
+}
+
+function insertAt(text: string, start: number, end: number, inserted: string): TextFormatResult {
+  const next = `${text.slice(0, start)}${inserted}${text.slice(end)}`;
+  const cursor = start + inserted.length;
+  return { text: next, selectionStart: cursor, selectionEnd: cursor };
+}
+
+/**
+ * Normalises a toolbar URL. Only `http:`/`https:` survive; anything else has
+ * its scheme stripped and is re-prefixed with `https://`, so a crafted
+ * `javascript:` URL can never become an anchor href.
+ */
+const SAFE_SCHEMES = new Set(['http:', 'https:']);
+
+export function normalizeLinkHref(raw: string): string {
+  const trimmed = (raw ?? '').trim();
+  if (!trimmed) return 'https://';
+  const schemeMatch = /^([a-zA-Z][a-zA-Z0-9+.-]*):/.exec(trimmed);
+  if (schemeMatch) {
+    const scheme = schemeMatch[1].toLowerCase();
+    if (SAFE_SCHEMES.has(`${scheme}:`)) return trimmed;
+    const rest = trimmed.slice(schemeMatch[0].length);
+    return `https://${rest}`;
+  }
+  return `https://${trimmed}`;
+}
+
+/**
+ * Wraps the selected range in `**`/`*`/`~~`/`__` markers. Returns `null` on a
+ * collapsed selection so a no-selection shortcut never injects stray markers.
+ */
+export function wrapInlineFormat(
+  text: string,
+  selection: TextSelection,
+  kind: InlineFormatKind,
+): TextFormatResult | null {
+  const { start, end } = clampSelection(text, selection);
+  if (start === end) return null;
+  const [open, close] = WRAP_MARKERS[kind];
+  return insertAt(text, start, end, `${open}${text.slice(start, end)}${close}`);
+}
+
+/**
+ * Turns a selection into a fenced code block or a quote (every selected line
+ * prefixed with `> `). Needs real content, like the inline formatters.
+ */
+export function wrapBlockFormat(
+  text: string,
+  selection: TextSelection,
+  kind: BlockFormatKind,
+): TextFormatResult | null {
+  const { start, end } = clampSelection(text, selection);
+  if (start === end) return null;
+  const selected = text.slice(start, end);
+
+  if (kind === 'quote') {
+    const quoted = selected
+      .split('\n')
+      .map((line) => `> ${line}`)
+      .join('\n');
+    return insertAt(text, start, end, quoted);
+  }
+
+  const wrapped = `\`\`\`\n${selected}\n\`\`\``;
+  return insertAt(text, start, end, wrapped);
+}
+
+/**
+ * Turns a selection into `[selection](url)`. With no selection, inserts
+ * `[text](url)` and selects the placeholder label so the user can type over it.
+ */
+export function applyLink(text: string, selection: TextSelection, rawUrl: string): TextFormatResult {
+  const { start, end } = clampSelection(text, selection);
+  const url = normalizeLinkHref(rawUrl);
+  const label = text.slice(start, end);
+
+  if (label) {
+    return insertAt(text, start, end, `[${label}](${url})`);
+  }
+
+  const inserted = `[text](${url})`;
+  const next = `${text.slice(0, start)}${inserted}${text.slice(end)}`;
+  const labelStart = start + 1;
+  return { text: next, selectionStart: labelStart, selectionEnd: labelStart + 'text'.length };
+}
+
+/** Ctrl/Cmd+B / I / D / U / Q shortcuts; `Q` is blockquote, never `link`. */
+const SHORTCUT_KIND: Record<string, TextFormatKind> = {
+  b: 'bold',
+  B: 'bold',
+  i: 'italic',
+  I: 'italic',
+  d: 'strike',
+  D: 'strike',
+  u: 'underline',
+  U: 'underline',
+  q: 'quote',
+  Q: 'quote',
+};
+
+export function shortcutFormatKind(event: { key: string }): TextFormatKind | null {
+  return SHORTCUT_KIND[event.key] ?? null;
+}


### PR DESCRIPTION
## Summary

PWA 聊天消息支持 Markdown:在不改变存储线格式(仍为纯文本)的前提下,新增渲染与输入能力。

- **渲染**:消息气泡内支持粗体 / 斜体 / 删除线 / 下划线 / 行内与围栏代码 / 列表 / 引用 / 链接与裸链接;聊天列表、搜索结果、回复/置顶预览渲染为安全的单行摘要(`MarkdownSummaryText`)。
- **输入**:输入框选中文本后弹出格式化工具栏(B / I / S / U / 代码 / 引用 / 链接),支持 `Ctrl+B/I/D/U/Q` 快捷键与链接 URL 弹窗;格式化结果与 @提及 文本线格式兼容。
- **安全**:基于 `markdown-it@15` 定制仅启用受控子集,强制 `html:false`,渲染层无 `dangerouslySetInnerHTML`,历史纯文本经 detect + normalize 保护、尽可能不被误渲染。
- **可控**:新增 `messageMarkdown` 功能开关(默认开启)。

纯前端改动,无后端 / 数据库 / 协议变更,Flutter 端不受影响。

## Test plan

- `npm run verify` 全绿:ESLint ✓ / tsc ✓ / 369 tests(67 files)✓
- 新增 8 个测试文件覆盖:引擎子集规则与 HTML/代码安全、选区格式化往返、提及 × 格式化组合、列表/搜索/预览单行渲染、功能开关行为。

## Risk & notes

- 含 `* _ ~ ` `` ` 的历史纯文本消息将按 Markdown 渲染;已收敛子集 + 归一化,建议灰度时重点回归纯文本群聊/公告消息。
- PWA 独有,同一消息在 Flutter 端仍显示原始标记(跨端差异,建议后续同步)。
- 回滚:受 `messageMarkdown` 开关控制,可先关开关再回滚。
